### PR TITLE
fix: remove outdated root vercel.json and add build artifacts to giti…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,13 @@ dist/
 .env.local
 *.tsbuildinfo
 
+# SvelteKit build outputs
+.svelte-kit/
+build/
+
+# macOS metadata
+.DS_Store
+
 # Terraform — never commit real tfvars or state
 infra/terraform/terraform.tfvars
 infra/terraform/.terraform/

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,0 @@
-{
-  "outputDirectory": "build"
-}


### PR DESCRIPTION
…gnore

The root vercel.json with outputDirectory=build was leftover from adapter-static and caused 500s on Vercel after migrating to adapter-vercel. Also adds .svelte-kit/, build/, and .DS_Store to gitignore.