### PR TITLE
feat(ui): refresh UI for OpenClaw architecture

### DIFF
--- a/.interface-design/system.md
+++ b/.interface-design/system.md
@@ -1,0 +1,163 @@
+# Claw Army — Interface Design System
+
+## Intent
+
+**Who:** Technical operators and founders in mission-launch mode. Decisive, comfortable with domain/provider concepts, wants to configure and fire fast.
+
+**What they do:** Launch AI bot crews against objectives. Monitor live execution. Review performance.
+
+**Feel:** Mission control terminal. Deep navy canvas, electric blue as the single signal color. Dense but not cluttered. Every element earns its place.
+
+---
+
+## Palette
+
+```
+--canvas:    #090d18   /* deep space navy — the ground everything sits on */
+--surface-0: #0d1221
+--surface-1: #121a2c   /* card background */
+--surface-2: #192236   /* input background, inner panels */
+--surface-3: #1e293f   /* hover state */
+
+--signal:        #3d7eff   /* electric blue — ONE accent, used sparingly */
+--signal-tint:   rgba(61, 126, 255, 0.10)
+--signal-border: rgba(61, 126, 255, 0.32)
+
+--active:        #22c55e   /* green — live, selected, allowed */
+--active-tint:   rgba(34, 197, 94, 0.10)
+--active-border: rgba(34, 197, 94, 0.30)
+
+--alert:    #f59e0b   /* amber — warnings, budget events */
+--critical: #ef4444   /* red — errors, failures */
+```
+
+**Why this palette:** Deep navy reads as command infrastructure — server rooms, terminals, mission dashboards. Blue is the only accent because restraint signals confidence. Green is reserved for live/active states only.
+
+---
+
+## Typography
+
+System stack: `system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif`
+
+Monospace stack: `ui-monospace, 'SF Mono', 'Cascadia Mono', monospace`
+
+- **Monospace is used for:** numbers, metrics, codes, tags, status badges, domain lists, technical identifiers
+- **Prose font is used for:** labels, descriptions, body copy
+
+**Why system fonts:** The product lives in the browser alongside DevTools, terminals, dashboards. Matching the OS font reads as native infrastructure, not a consumer app.
+
+---
+
+## Depth
+
+Borders only — no shadows on cards or panels. Surfaces elevate strictly through background color:
+
+```
+canvas → surface-0 → surface-1 → surface-2 → surface-3
+```
+
+**Why no shadows:** Shadows imply physical depth and warmth. This product is a control surface — flat, layered planes read as a terminal, not a card deck.
+
+---
+
+## Spacing
+
+Base unit: 8px (`--s-4 = 1rem`)
+
+Scale: `--s-1` (2px) through `--s-24` (6rem). Use the scale — never raw pixel values.
+
+---
+
+## Radius
+
+```
+--r-sm: 3px   /* inputs, buttons, badges — tight, not pill */
+--r-md: 6px   /* cards, panels */
+--r-lg: 10px  /* large containers */
+```
+
+---
+
+## Components
+
+### Panel
+
+The primary container unit in forms and dashboards.
+
+```css
+background: var(--surface-1);
+border: 1px solid var(--border);
+border-radius: var(--r-md);
+padding: var(--s-5) var(--s-6);
+```
+
+Panel label uses uppercase tracking + monospace step number in signal color.
+
+### Toggle Button (tool-toggle)
+
+Used for binary or single-select choices (provider selection, feature flags). NOT checkbox-style — clicking once selects, clicking another deselects.
+
+- **Inactive:** surface-2 background, faint border, circle SVG in indicator
+- **Active:** active-tint background, active-border, checkmark SVG, green badge
+
+Badge text conventions:
+- Feature toggles: `ALLOWED` / `BLOCKED`
+- Single-select (provider): `SELECTED` on active only, nothing on inactive
+
+### Monospace Input
+
+For technical values (domain lists, API keys, identifiers):
+
+```css
+font-family: ui-monospace, 'SF Mono', 'Cascadia Mono', monospace;
+font-size: 0.8125rem;
+line-height: 1.7;
+```
+
+Applied as an additional class on the shared `textarea` base.
+
+### Status Badges
+
+```
+font-family: monospace
+font-size: 0.625rem
+font-weight: 700
+letter-spacing: 0.08em
+padding: 0.1875rem 0.4375rem
+border-radius: var(--r-sm)
+```
+
+Colors follow semantic tokens: signal (info), active (live/ok), alert (warning), critical (error).
+
+### Row Panels
+
+Two equal-width panels side by side, gap `--s-4`. Used for paired config controls (Crew Size + Budget, LLM Provider + Egress Perimeter).
+
+```css
+display: grid;
+grid-template-columns: 1fr 1fr;
+gap: var(--s-4);
+```
+
+Collapses to single column below 600px.
+
+---
+
+## Copy Conventions
+
+- **Mission language throughout:** "crew", "deploy", "mission", "objective", "perimeter" — not "team", "run", "task", "goal", "filter"
+- **Step numbers:** monospace `01` / `02` etc — signal colored, no period
+- **Section tags:** 2-letter monospace all-caps in a tinted pill (`EP`, `EX`, `MC`)
+- **Metric display:** large monospace number + small muted label below
+- **Hints:** `0.8125rem`, `--text-muted`, 1.5 line height — below the label, above the input
+
+---
+
+## What to Avoid
+
+- Shadows on cards (breaks the terminal feel)
+- More than one accent color per view
+- Pill/full-radius buttons (use `--r-sm` = 3px)
+- Warm surface colors (beige, cream — wrong world entirely)
+- Emoji in UI copy
+- "Clean", "modern", "minimal" as design goals — describe the *world*, not the aesthetic

--- a/services/ui/src/routes/+page.svelte
+++ b/services/ui/src/routes/+page.svelte
@@ -106,19 +106,19 @@
 
         <div class="cap-card">
           <div class="cap-top">
-            <span class="cap-tag">TA</span>
-            <h3>Tool Access Control</h3>
+            <span class="cap-tag">EP</span>
+            <h3>Egress Perimeter</h3>
           </div>
-          <p>Decide exactly what bots can do per mission. Allow or restrict LLM calls, web fetch, and file writes. Bots operate within the perimeter you define — nothing beyond.</p>
+          <p>Each bot gets a dedicated machine — full bash access, a real browser, complete filesystem. All outbound traffic routes through a metered proxy. You define which domains they can reach. Nothing else gets out.</p>
           <div class="cap-footer">
-            <span class="cap-metric">3</span>
-            <span class="cap-metric-label">permission-gated tools</span>
+            <span class="cap-metric">Proxy</span>
+            <span class="cap-metric-label">gated egress</span>
           </div>
         </div>
 
         <div class="cap-card cap-card--cta">
           <h3>Ready to run a mission?</h3>
-          <p>Configure your objective, set crew size and budget, and deploy. Under 60 seconds to first launch.</p>
+          <p>Configure your objective, set crew size and budget, and deploy. First bot online in minutes.</p>
           <a href="/new-execution" class="btn-primary">Start Mission →</a>
         </div>
 

--- a/services/ui/src/routes/new-execution/+page.server.ts
+++ b/services/ui/src/routes/new-execution/+page.server.ts
@@ -27,7 +27,9 @@ export const actions: Actions = {
     const maxBots = Number(formData.get('maxBots') ?? 3);
     const budgetCapDollars = Number(formData.get('budgetCapDollars') ?? 10);
     const budgetCapCents = Math.round(budgetCapDollars * 100);
-    const allowedTools = formData.getAll('allowedTools') as string[];
+    const llmProvider = (formData.get('llmProvider') as string | null) ?? 'anthropic';
+    const allowedDomainsRaw = (formData.get('allowedDomains') as string | null) ?? '';
+    const allowedDomains = allowedDomainsRaw.split(',').map(d => d.trim()).filter(Boolean);
 
     // Extract Auth.js session token from cookies
     // Auth.js uses 'authjs.session-token' on HTTP (dev) and '__Secure-authjs.session-token' on HTTPS (prod)
@@ -48,7 +50,7 @@ export const actions: Actions = {
           'Content-Type': 'application/json',
           ...(sessionToken ? { Authorization: `Bearer ${sessionToken}` } : {}),
         },
-        body: JSON.stringify({ objective, maxBots, budgetCapCents, allowedTools }),
+        body: JSON.stringify({ objective, maxBots, budgetCapCents, llmProvider, allowedDomains }),
       });
     } catch (err) {
       return fail(503, { error: 'Could not reach execution service. Please try again.' });

--- a/services/ui/src/routes/new-execution/+page.svelte
+++ b/services/ui/src/routes/new-execution/+page.svelte
@@ -2,29 +2,23 @@
   import { enhance } from '$app/forms';
   import type { ActionData } from './$types';
 
-  const TOOLS: { id: string; label: string; description: string }[] = [
-    { id: 'llm_call',   label: 'LLM Call',   description: 'Prompt any language model' },
-    { id: 'fetch_url',  label: 'Web Fetch',  description: 'Retrieve content from URLs' },
-    { id: 'write_file', label: 'File Write', description: 'Write output to the filesystem' },
+  const LLM_PROVIDERS: { id: string; label: string; description: string }[] = [
+    { id: 'anthropic', label: 'Anthropic', description: 'Claude models via Anthropic API' },
+    { id: 'openai',    label: 'OpenAI',    description: 'GPT models via OpenAI API' },
   ];
+
+  const DEFAULT_DOMAINS = 'api.anthropic.com, api.openai.com, github.com, objects.githubusercontent.com, registry.npmjs.org';
 
   let { form } = $props<{ form: ActionData }>();
 
-  let objective         = $state('');
-  let maxBots           = $state(3);
-  let budgetCapDollars  = $state(10);
-  let allowedTools      = $state<string[]>(['llm_call', 'fetch_url', 'write_file']);
-  let submitting        = $state(false);
+  let objective        = $state('');
+  let maxBots          = $state(3);
+  let budgetCapDollars = $state(10);
+  let llmProvider      = $state('anthropic');
+  let allowedDomains   = $state(DEFAULT_DOMAINS);
+  let submitting       = $state(false);
 
   let error = $derived(form?.error ?? null);
-
-  function toggleTool(id: string) {
-    if (allowedTools.includes(id)) {
-      allowedTools = allowedTools.filter((t) => t !== id);
-    } else {
-      allowedTools = [...allowedTools, id];
-    }
-  }
 </script>
 
 <svelte:head>
@@ -123,43 +117,63 @@
       </div>
     </div>
 
-    <!-- Tool Permissions -->
-    <div class="panel">
-      <div class="panel-label">
-        <span class="panel-tag">04</span>
-        Tool Permissions
-      </div>
-      <p class="panel-hint">Grant bots access to these capabilities. Unchecked tools are blocked entirely.</p>
-      <div class="tools-grid">
-        {#each TOOLS as tool}
-          <button
-            type="button"
-            class="tool-toggle"
-            class:active={allowedTools.includes(tool.id)}
-            onclick={() => toggleTool(tool.id)}
-          >
-            <div class="tool-indicator">
-              {#if allowedTools.includes(tool.id)}
-                <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
-                  <path d="M1.5 5L4 7.5L8.5 2.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-              {:else}
-                <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
-                  <path d="M2.5 2.5L7.5 7.5M7.5 2.5L2.5 7.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-                </svg>
+    <!-- LLM Provider + Egress Perimeter -->
+    <div class="row-panels">
+
+      <div class="panel">
+        <div class="panel-label">
+          <span class="panel-tag">04</span>
+          LLM Provider
+        </div>
+        <p class="panel-hint">Which model powers the crew.</p>
+        <div class="tools-grid">
+          {#each LLM_PROVIDERS as provider}
+            <button
+              type="button"
+              class="tool-toggle"
+              class:active={llmProvider === provider.id}
+              onclick={() => llmProvider = provider.id}
+            >
+              <div class="tool-indicator">
+                {#if llmProvider === provider.id}
+                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+                    <path d="M1.5 5L4 7.5L8.5 2.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                {:else}
+                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+                    <circle cx="5" cy="5" r="3" stroke="currentColor" stroke-width="1.5"/>
+                  </svg>
+                {/if}
+              </div>
+              <div class="tool-info">
+                <span class="tool-label">{provider.label}</span>
+                <span class="tool-desc">{provider.description}</span>
+              </div>
+              {#if llmProvider === provider.id}
+                <span class="tool-status">SELECTED</span>
               {/if}
-            </div>
-            <div class="tool-info">
-              <span class="tool-label">{tool.label}</span>
-              <span class="tool-desc">{tool.description}</span>
-            </div>
-            <span class="tool-status">{allowedTools.includes(tool.id) ? 'ALLOWED' : 'BLOCKED'}</span>
-          </button>
-        {/each}
+            </button>
+          {/each}
+        </div>
+        <input type="hidden" name="llmProvider" value={llmProvider} />
       </div>
-      {#each allowedTools as tool}
-        <input type="hidden" name="allowedTools" value={tool} />
-      {/each}
+
+      <div class="panel">
+        <div class="panel-label">
+          <span class="panel-tag">05</span>
+          Egress Perimeter
+        </div>
+        <p class="panel-hint">Domains bots can reach via the proxy. All other outbound traffic is blocked.</p>
+        <textarea
+          id="allowedDomains"
+          name="allowedDomains"
+          bind:value={allowedDomains}
+          rows="4"
+          spellcheck="false"
+          class="domains-input"
+        ></textarea>
+      </div>
+
     </div>
 
     {#if error}
@@ -410,6 +424,13 @@
     font-size: 0.8125rem;
     color: var(--text-muted);
     line-height: 1.5;
+  }
+
+  /* ── Domains input ── */
+  .domains-input {
+    font-family: ui-monospace, 'SF Mono', 'Cascadia Mono', monospace;
+    font-size: 0.8125rem;
+    line-height: 1.7;
   }
 
   /* ── Tool toggles ── */


### PR DESCRIPTION
## Summary

- **Home page** — "Tool Access Control" card replaced with "Egress Perimeter": copy now accurately describes full-machine-access bots with proxy-gated domain control. "Under 60 seconds to first launch" removed (GCE VM boot is ~3 min) → "First bot online in minutes."
- **New execution form** — old tool toggle panel (llm_call / fetch_url / write_file) replaced with two panels that reflect what actually matters with OpenClaw: which LLM provider powers the crew, and which domains they can egress to via the proxy
- **Design system** — `.interface-design/system.md` created, capturing tokens, component patterns, and copy conventions for future UI work

## What changed visually

**Panel 04 — LLM Provider:** Same toggle-button visual as the old tool toggles. Circle indicator for unselected state (vs. checkmark for selected). Green `SELECTED` badge on the active choice, nothing on the inactive one.

**Panel 05 — Egress Perimeter:** Monospace textarea pre-filled with sensible defaults (`api.anthropic.com, api.openai.com, github.com, objects.githubusercontent.com, registry.npmjs.org`). Hint copy: "Domains bots can reach via the proxy. All other outbound traffic is blocked."

## Form action

`+page.server.ts` now reads `llmProvider` + `allowedDomains` (parsed from comma-separated) and passes both to the execution service. `allowedTools` removed.

## Test plan

- [ ] `/new-execution` loads without errors
- [ ] LLM Provider toggles correctly between Anthropic / OpenAI (green badge follows selection)
- [ ] Egress Perimeter textarea shows monospace defaults, accepts edits
- [ ] Form submits successfully → redirects to execution page
- [ ] Home page capability card shows "Egress Perimeter" copy
- [ ] No TypeScript errors (`tsc --noEmit` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)