### PR TITLE
fix(activity-feed): publish missing task_claimed and execution_status_changed events

### DIFF
--- a/services/execution-service/src/queue/openclaw-dispatcher.ts
+++ b/services/execution-service/src/queue/openclaw-dispatcher.ts
@@ -11,7 +11,7 @@ import {
   releaseBot,
   getBotsForExecution,
 } from '../orchestrator/bot-registry';
-import { publishTaskCompleted } from '../events/publisher';
+import { publishTaskClaimed, publishTaskCompleted } from '../events/publisher';
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Constants
@@ -126,6 +126,17 @@ async function dispatchTaskToBot(
       updatedAt: new Date(),
     })
     .where(eq(bots.id, botId));
+
+  // Publish task_claimed event
+  await publishTaskClaimed({
+    type: 'task_claimed',
+    taskId,
+    executionId,
+    botId,
+    timestamp: new Date().toISOString(),
+  }).catch((err: Error) => {
+    console.error('[openclaw-dispatcher] Failed to publish task_claimed (non-fatal):', err.message);
+  });
 
   // Keep the job lock alive while waiting (renew every 20s)
   const renewInterval = setInterval(() => {

--- a/services/execution-service/src/routes/executions.ts
+++ b/services/execution-service/src/routes/executions.ts
@@ -16,6 +16,7 @@ import {
   startQueueEventListener,
   stopBot,
 } from '../orchestrator/bot-orchestrator';
+import { publishExecutionStatusChanged } from '../events/publisher';
 import { getBotsForExecution } from '../orchestrator/bot-registry';
 import { startCompletionPoller } from '../orchestrator/completion-checker';
 import { buildExecutionReport } from '../performance/report-builder';
@@ -108,6 +109,16 @@ export const executionsRoutes: FastifyPluginAsyncTypebox = async (fastify) => {
           fastify.log.error({ executionId }, 'Failed to transition to running');
           return;
         }
+
+        await publishExecutionStatusChanged({
+          type: 'execution_status_changed',
+          executionId,
+          fromStatus: 'queued',
+          toStatus: 'running',
+          timestamp: new Date().toISOString(),
+        }).catch((err: Error) => {
+          fastify.log.error({ err, executionId }, 'Failed to publish execution_status_changed (non-fatal)');
+        });
 
         // 4. Spawn bots for this execution
         await spawnBotsForExecution(executionId, maxBots);


### PR DESCRIPTION
## Summary

- **`openclaw-dispatcher`**: `publishTaskClaimed` was never called — bots were marking tasks as claimed in the DB but the `task_claimed` Pub/Sub event was never emitted, so the SSE activity feed showed nothing during task execution
- **`executions` route**: `publishExecutionStatusChanged` was not called for the `queued→running` transition — the UI status banner stayed stuck on "QUEUED" via SSE until completion

## Root cause

Both functions were defined in `publisher.ts` and exported, but never imported or called at the relevant dispatch/transition points.

## Test plan

- [ ] Create an execution and navigate to the execution page
- [ ] Confirm activity feed shows `Execution Status Changed` (queued → running) shortly after creation
- [ ] Confirm activity feed shows `Task Claimed` entries as bots pick up tasks
- [ ] Confirm activity feed shows `Task Completed` entries when tasks finish
- [ ] Confirm no regressions: bot cards still appear via polling, metrics still update

🤖 Generated with [Claude Code](https://claude.com/claude-code)