### PR TITLE
fix: attach service account to bot VMs and fix tool gateway URL

### DIFF
--- a/services/execution-service/src/orchestrator/bot-orchestrator.ts
+++ b/services/execution-service/src/orchestrator/bot-orchestrator.ts
@@ -29,10 +29,15 @@ const GCP_PROJECT_ID = process.env.GCP_PROJECT_ID ?? 'claw-local';
 const GCP_ZONE = process.env.GCP_ZONE ?? 'us-central1-a';
 const GCP_NETWORK = process.env.GCP_NETWORK ?? 'default';
 const GCP_SUBNET = process.env.GCP_SUBNET ?? 'default';
-const TOOL_GATEWAY_URL = process.env.TOOL_GATEWAY_URL ?? 'tool-gateway:3002';
+const TOOL_GATEWAY_URL = process.env.TOOL_GATEWAY_URL ?? 'http://tool-gateway:3002';
+// VPC-accessible URL for bot VMs (use internal IP, not Docker container name).
+// Falls back to TOOL_GATEWAY_URL if not set (works for local dev where Docker DNS resolves).
+const TOOL_GATEWAY_VPC_URL = process.env.TOOL_GATEWAY_VPC_URL ?? TOOL_GATEWAY_URL;
 const EXECUTION_SERVICE_URL = process.env.EXECUTION_SERVICE_URL ?? 'http://localhost:3001';
 const LLM_API_KEY_SECRET_NAME = process.env.LLM_API_KEY_SECRET_NAME ?? 'llm-api-key';
 const LLM_PROVIDER = process.env.LLM_PROVIDER ?? 'anthropic';
+// Service account for bot VMs — must have roles/secretmanager.secretAccessor
+const GCP_BOT_SERVICE_ACCOUNT = process.env.GCP_BOT_SERVICE_ACCOUNT ?? 'claw-app-dev@claw-army.iam.gserviceaccount.com';
 
 // ──────────────────────────────────────────────────────────────────────────────
 // spawnBot
@@ -79,10 +84,11 @@ export async function spawnBot(
       zone: GCP_ZONE,
       network: GCP_NETWORK,
       subnet: GCP_SUBNET,
-      toolGatewayUrl: TOOL_GATEWAY_URL,
+      toolGatewayUrl: TOOL_GATEWAY_VPC_URL,
       executionServiceUrl: EXECUTION_SERVICE_URL,
       llmApiKeySecretName: LLM_API_KEY_SECRET_NAME,
       llmProvider: LLM_PROVIDER,
+      botServiceAccount: GCP_BOT_SERVICE_ACCOUNT,
     });
     instanceName = result.instanceName;
   } catch (err) {

--- a/services/execution-service/src/orchestrator/gce-bot-launcher.ts
+++ b/services/execution-service/src/orchestrator/gce-bot-launcher.ts
@@ -78,12 +78,12 @@ cat > /root/.openclaw/config.json <<CONFIG
 {
   "llmProvider": "$LLM_PROVIDER",
   "apiKey": "$LLM_API_KEY",
-  "httpProxy": "http://$TOOL_GATEWAY_URL"
+  "httpProxy": "$TOOL_GATEWAY_URL"
 }
 CONFIG
 
-export HTTP_PROXY="http://$TOOL_GATEWAY_URL"
-export HTTPS_PROXY="http://$TOOL_GATEWAY_URL"
+export HTTP_PROXY="$TOOL_GATEWAY_URL"
+export HTTPS_PROXY="$TOOL_GATEWAY_URL"
 export NO_PROXY="metadata.google.internal,169.254.169.254,localhost,127.0.0.1"
 # Override gateway bind address from 127.0.0.1 to the internal VPC IP
 export OPENCLAW_GATEWAY_HOST="$INTERNAL_IP"
@@ -136,6 +136,8 @@ export interface LaunchBotVMOptions {
   executionServiceUrl: string;
   llmApiKeySecretName: string;
   llmProvider?: string;
+  /** Service account email to attach to bot VMs (needs secretmanager.secretAccessor). */
+  botServiceAccount: string;
 }
 
 /**
@@ -205,6 +207,12 @@ export async function launchBotVM(opts: LaunchBotVMOptions): Promise<{ instanceN
         'bot-id': opts.botId.slice(0, 8).replace(/-/g, ''),
         'execution-id': opts.executionId.slice(0, 8).replace(/-/g, ''),
       },
+      serviceAccounts: [
+        {
+          email: opts.botServiceAccount,
+          scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+        },
+      ],
       tags: {
         items: ['claw-bot-vm'],
       },


### PR DESCRIPTION
Bot startup scripts were always failing with exit 1 due to two bugs:

1. GCE bot VMs were created with no service account, so `gcloud secrets versions access` could not authenticate and LLM_API_KEY was always empty. Fixed by attaching claw-app-dev SA (secretmanager.secretAccessor) via new `botServiceAccount` param in LaunchBotVMOptions, configurable with GCP_BOT_SERVICE_ACCOUNT env var.

2. TOOL_GATEWAY_URL used the Docker container name `tool-gateway` which doesn't resolve from GCE VMs (VPC network). Added TOOL_GATEWAY_VPC_URL env var (defaults to TOOL_GATEWAY_URL) so bot VMs receive the internal IP (10.0.0.3:3002). Also removed the double http:// prefix bug in the startup script template where http:// was prepended to a URL that already included the scheme.