### PR TITLE
fix(ui): fix inner-page nav overlap, spacing vars, and page headers

### DIFF
--- a/services/ui/src/app.css
+++ b/services/ui/src/app.css
@@ -45,6 +45,20 @@
   --font-display: 'Clash Display', 'Inter', system-ui, sans-serif;
   --font-body:    'Inter', system-ui, sans-serif;
   --font-mono:    'JetBrains Mono', monospace;
+
+  /* ── SPACING SCALE (4px base) ────────────────── */
+  --s-1:  4px;
+  --s-2:  8px;
+  --s-3:  12px;
+  --s-4:  16px;
+  --s-5:  20px;
+  --s-6:  24px;
+  --s-7:  28px;
+  --s-8:  32px;
+  --s-9:  36px;
+  --s-10: 40px;
+  --s-11: 44px;
+  --s-12: 48px;
 }
 
 html { scroll-behavior: smooth; }

--- a/services/ui/src/routes/billing/+page.svelte
+++ b/services/ui/src/routes/billing/+page.svelte
@@ -21,7 +21,8 @@
 </svelte:head>
 
 <div class="page">
-  <h1>Usage & Billing</h1>
+  <div class="sec-label">Usage & Billing</div>
+  <h1>This month at a glance.</h1>
   <p class="subtitle">Monthly usage summary and historical execution costs.</p>
 
   {#if loading}
@@ -95,21 +96,24 @@
   .page {
     max-width: 1000px;
     margin: 0 auto;
+    padding: 100px 36px 80px;
   }
 
   h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
     font-family: var(--font-display);
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    font-weight: 600;
+    letter-spacing: -0.025em;
     color: var(--text);
-    margin: 0 0 0.25rem;
+    margin: 0 0 0.5rem;
   }
 
   .subtitle {
     color: var(--text-muted);
-    margin: 0 0 2rem;
-    font-size: 0.9rem;
+    margin: 0 0 2.5rem;
+    font-size: 1rem;
     font-family: var(--font-body);
+    line-height: 1.6;
   }
 
   .loading {
@@ -145,6 +149,10 @@
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 1rem;
+  }
+
+  @media (max-width: 960px) {
+    .page { padding: 100px 24px 60px; }
   }
 
   @media (max-width: 768px) {

--- a/services/ui/src/routes/guide/+page.svelte
+++ b/services/ui/src/routes/guide/+page.svelte
@@ -502,6 +502,7 @@
   .guide {
     max-width: 820px;
     margin: 0 auto;
+    padding: 100px 36px 80px;
   }
 
   /* ── Page header ── */
@@ -1335,6 +1336,10 @@
   }
 
   /* ── Responsive ── */
+  @media (max-width: 960px) {
+    .guide { padding: 100px 24px 60px; }
+  }
+
   @media (max-width: 768px) {
     .steps-row {
       flex-direction: column;

--- a/services/ui/src/routes/objectives/+page.svelte
+++ b/services/ui/src/routes/objectives/+page.svelte
@@ -20,13 +20,17 @@
 </svelte:head>
 
 <div class="page">
-  <h1>Objectives</h1>
+  <div class="sec-label">Objectives</div>
+  <h1>Mission library.</h1>
   <p class="subtitle">Your saved objectives and their run history.</p>
 
   {#if loading}
     <div class="loading">Loading...</div>
   {:else if error}
-    <div class="error">{error}</div>
+    <div class="error">
+      <span class="error-title">Unable to load objectives</span>
+      <span class="error-detail">{error}</span>
+    </div>
   {:else}
     {#if objectives.length === 0}
       <p class="empty">No objectives yet. Create one from the Deploy Crew page.</p>
@@ -79,20 +83,23 @@
   .page {
     max-width: 1000px;
     margin: 0 auto;
+    padding: 100px 36px 80px;
   }
 
   h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    margin: 0 0 0.25rem;
     font-family: var(--font-display);
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    font-weight: 600;
+    letter-spacing: -0.025em;
+    margin: 0 0 0.5rem;
     color: var(--text);
   }
 
   .subtitle {
     color: var(--text-muted);
-    margin: 0 0 2rem;
-    font-size: 0.9rem;
+    margin: 0 0 2.5rem;
+    font-size: 1rem;
+    line-height: 1.6;
   }
 
   .loading {
@@ -102,16 +109,34 @@
   }
 
   .error {
-    padding: 1rem;
+    padding: 1.25rem 1.5rem;
     background: var(--error-dim);
     border: 1px solid rgba(248,113,113,0.25);
-    border-radius: 0.5rem;
+    border-radius: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .error-title {
     color: var(--error);
+    font-weight: 600;
+    font-size: 0.9375rem;
+  }
+
+  .error-detail {
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
   }
 
   .empty {
     color: var(--text-muted);
     font-style: italic;
+  }
+
+  @media (max-width: 960px) {
+    .page { padding: 100px 24px 60px; }
   }
 
   /* Objectives table */

--- a/services/ui/src/routes/verdicts/+page.svelte
+++ b/services/ui/src/routes/verdicts/+page.svelte
@@ -59,6 +59,7 @@
 <div class="page">
   <div class="page-header">
     <div>
+      <div class="sec-label">Governance</div>
       <h1>Pending Verdicts</h1>
       <p class="subtitle">Promote and Retire verdicts require your review.</p>
     </div>
@@ -115,28 +116,31 @@
   .page {
     max-width: 1100px;
     margin: 0 auto;
+    padding: 100px 36px 80px;
   }
 
   .page-header {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
-    margin-bottom: 1.5rem;
+    margin-bottom: 2rem;
     gap: 1rem;
   }
 
   h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    margin: 0 0 0.25rem;
     font-family: var(--font-display);
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    font-weight: 600;
+    letter-spacing: -0.025em;
+    margin: 0 0 0.5rem;
     color: var(--text);
   }
 
   .subtitle {
     color: var(--text-muted);
-    font-size: 0.875rem;
+    font-size: 1rem;
     margin: 0;
+    line-height: 1.6;
   }
 
   .calibration-warning {
@@ -174,6 +178,10 @@
     display: grid;
     grid-template-columns: 1fr;
     gap: 1rem;
+  }
+
+  @media (max-width: 960px) {
+    .page { padding: 100px 24px 60px; }
   }
 
   @media (min-width: 768px) {


### PR DESCRIPTION
## Summary

- **Nav overlap** — Guide, Billing, Verdicts, and Objectives pages were rendering their content starting at `top: 0`, directly behind the fixed nav bar. Added `padding: 100px 36px 80px` (reduced to `24px` horizontal on mobile) to each inner-page wrapper so content sits properly below the nav.
- **Spacing scale** — The Guide page referenced CSS custom properties `--s-1` through `--s-12` throughout its styles, but these were never defined in `app.css`. Added a 4px-base spacing scale to `:root`, which restores all internal Guide spacing (section padding, margins, gaps).
- **Landing-page header parity** — Billing, Verdicts, and Objectives page headers updated to use the `sec-label` eyebrow tag (mono uppercase with trailing rule) above the h1, and the display-font heading style with `clamp` sizing and tight letter-spacing — matching the landing page's visual language.
- **Objectives error state** — Instead of dumping the raw API error string (`API error 404: Not Found — /api/objectives`), the error block now shows a clear user-facing title with the technical detail in smaller mono text below it. The backend 404 is a server-side issue; this makes it readable rather than alarming.

## Test plan

- [ ] Navigate to `/guide` — content should start below the nav bar; section spacing should be visible
- [ ] Navigate to `/billing` — content below nav, sec-label eyebrow visible above heading
- [ ] Navigate to `/verdicts` — same as billing
- [ ] Navigate to `/objectives` — same; if API returns 404, verify the error state shows "Unable to load objectives" cleanly
- [ ] Resize browser to ≤960px on each page — horizontal padding should reduce gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)