### PR TITLE
feat(ui): add Deploy Crew button to nav and objectives page

### DIFF
--- a/services/ui/src/routes/+layout.svelte
+++ b/services/ui/src/routes/+layout.svelte
@@ -185,6 +185,7 @@
           <span class="live-dot"></span>Platform live
         </div>
         {#if session?.user}
+          <a href="/new-execution" class="btn-deploy">Deploy crew</a>
           <button class="btn-nav" onclick={() => signOut({ redirectTo: '/' })}>Sign out</button>
         {:else}
           <a href="#access" class="btn-nav">Request access</a>
@@ -278,7 +279,20 @@
 
   .nav-links a:hover { color: var(--violet-light); }
 
-  .nav-right { display: flex; align-items: center; gap: 20px; }
+  .nav-right { display: flex; align-items: center; gap: 14px; }
+
+  .btn-deploy {
+    display: inline-flex; align-items: center;
+    padding: 0.45rem 1rem;
+    background: var(--violet);
+    color: white;
+    font-size: 13px; font-weight: 600;
+    border-radius: 8px;
+    text-decoration: none;
+    transition: background 0.15s;
+  }
+
+  .btn-deploy:hover { background: var(--violet-bright); }
 
   .status-pill {
     display: flex; align-items: center; gap: 7px;

--- a/services/ui/src/routes/objectives/+page.svelte
+++ b/services/ui/src/routes/objectives/+page.svelte
@@ -20,9 +20,14 @@
 </svelte:head>
 
 <div class="page">
-  <div class="sec-label">Objectives</div>
-  <h1>Mission library.</h1>
-  <p class="subtitle">Your saved objectives and their run history.</p>
+  <div class="page-header">
+    <div>
+      <div class="sec-label">Objectives</div>
+      <h1>Mission library.</h1>
+      <p class="subtitle">Your saved objectives and their run history.</p>
+    </div>
+    <a href="/new-execution" class="btn-deploy">Deploy new crew</a>
+  </div>
 
   {#if loading}
     <div class="loading">Loading...</div>
@@ -33,7 +38,7 @@
     </div>
   {:else}
     {#if objectives.length === 0}
-      <p class="empty">No objectives yet. Create one from the Deploy Crew page.</p>
+      <p class="empty">No objectives yet. Deploy a crew above to get started.</p>
     {:else}
       <div class="table-wrapper">
         <table>
@@ -85,6 +90,32 @@
     margin: 0 auto;
     padding: 100px 36px 80px;
   }
+
+  .page-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1.5rem;
+    margin-bottom: 0;
+  }
+
+  .btn-deploy {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.55rem 1.1rem;
+    background: var(--violet);
+    color: white;
+    font-size: 13.5px;
+    font-weight: 600;
+    border-radius: 10px;
+    text-decoration: none;
+    white-space: nowrap;
+    flex-shrink: 0;
+    margin-top: 2.25rem;
+    transition: background 0.15s;
+  }
+
+  .btn-deploy:hover { background: var(--violet-bright); }
 
   h1 {
     font-family: var(--font-display);


### PR DESCRIPTION
## Summary
- Adds a **Deploy crew** button to the nav bar (right side, visible when signed in) linking to `/new-execution`
- Adds a **Deploy new crew** button to the objectives list page header as a prominent CTA
- Updates the empty-state copy on the objectives page to reference the new button instead of the old placeholder text

## Why
There was no way for a user to navigate to the `/new-execution` deploy flow from anywhere in the app. The objectives empty state even referenced a "Deploy Crew page" as if it existed in the nav, but there was no such link.

## Test plan
- [ ] Sign in and verify "Deploy crew" button appears in the nav bar
- [ ] Click nav button → navigates to `/new-execution`
- [ ] Visit `/objectives` → verify "Deploy new crew" button appears in the top-right of the header
- [ ] Click objectives button → navigates to `/new-execution`
- [ ] Sign out → verify deploy button does not appear in nav (only "Request access" shows)
- [ ] On mobile (<960px), verify layout doesn't break with the nav changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)