### PR TITLE
fix(ui): fix nav overlap on bot/report pages and deploy crew navigation

### DIFF
--- a/services/ui/src/routes/executions/[id]/bots/[botId]/+page.svelte
+++ b/services/ui/src/routes/executions/[id]/bots/[botId]/+page.svelte
@@ -345,9 +345,15 @@
   .page {
     max-width: 1100px;
     margin: 0 auto;
-    padding: 1.5rem;
+    padding: 96px 36px 80px;
     background: var(--bg);
     min-height: 100vh;
+  }
+
+  @media (max-width: 600px) {
+    .page {
+      padding: 88px 20px 60px;
+    }
   }
 
   .breadcrumb {

--- a/services/ui/src/routes/executions/[id]/report/+page.svelte
+++ b/services/ui/src/routes/executions/[id]/report/+page.svelte
@@ -204,9 +204,15 @@
   .page {
     max-width: 1100px;
     margin: 0 auto;
-    padding: 1.5rem;
+    padding: 96px 36px 80px;
     background: var(--bg);
     min-height: 100vh;
+  }
+
+  @media (max-width: 600px) {
+    .page {
+      padding: 88px 20px 60px;
+    }
   }
 
   .breadcrumb {

--- a/services/ui/src/routes/new-execution/+page.svelte
+++ b/services/ui/src/routes/new-execution/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { enhance } from '$app/forms';
+  import { goto } from '$app/navigation';
   import { page } from '$app/state';
   import type { ActionData } from './$types';
   import { getArmyBuilderAnalysis } from '$lib/api';
@@ -83,9 +84,13 @@
     method="POST"
     use:enhance={() => {
       submitting = true;
-      return async ({ update }) => {
+      return async ({ result, update }) => {
         submitting = false;
-        await update({ reset: false });
+        if (result.type === 'redirect') {
+          await goto(result.location);
+        } else {
+          await update({ reset: false });
+        }
       };
     }}
   >


### PR DESCRIPTION
## Summary

- **Nav overlap fix**: Bot detail (`/executions/[id]/bots/[botId]`) and execution report (`/executions/[id]/report`) pages were using `padding: 1.5rem` (24px top), causing page content to render behind the fixed nav bar. Updated to `padding: 96px 36px 80px` to match the pattern used on other pages, with `88px 20px 60px` on mobile.
- **Deploy crew navigation**: The "Launch Mission" button was showing the loading spinner then silently resetting with no navigation or error feedback. Fixed by importing `goto` and explicitly handling the redirect in the `use:enhance` callback — on a successful deploy the user is now navigated directly to the execution view.

## Test plan

- [ ] Visit `/executions/{id}/bots/{botId}` — content should start below the nav bar
- [ ] Visit `/executions/{id}/report` — content should start below the nav bar
- [ ] Submit the new mission form — on success should navigate to `/executions/{id}`
- [ ] Submit with execution service down — should stay on page and show error banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)