### PR TITLE
fix(bot-vm): bind OpenClaw gateway to LAN interface

### DIFF
--- a/services/execution-service/src/orchestrator/gce-bot-launcher.ts
+++ b/services/execution-service/src/orchestrator/gce-bot-launcher.ts
@@ -127,13 +127,19 @@ if [[ -z "$LLM_API_KEY" ]]; then
 fi
 
 # ── 5. Configure OpenClaw non-interactively ───────────────────────────────────
+# Set OPENCLAW_GATEWAY_HOST so the gateway daemon binds to the LAN interface
+# (not loopback). Without this, openclaw defaults to 127.0.0.1 and the
+# execution-service cannot reach it over the VPC network.
+export OPENCLAW_GATEWAY_HOST="$INTERNAL_IP"
+export OPENCLAW_GATEWAY_PORT="$GATEWAY_PORT"
+
 # Run onboard WITHOUT HTTP_PROXY so openclaw can reach any setup URLs it needs
 # (npm CDNs, update checks, etc.) without being blocked by the Tool Gateway allowlist.
 # The proxy is injected into the openclaw systemd service AFTER onboard completes.
 #
-# NOTE: openclaw onboard --gateway-bind lan will exit non-zero because its internal
-# verification step connects to ws://127.0.0.1:18789 (loopback) but the gateway is
-# bound to the LAN interface, not loopback. The gateway IS running correctly — the
+# NOTE: openclaw onboard internal verification connects to ws://127.0.0.1:18789
+# (loopback) even when OPENCLAW_GATEWAY_HOST is set to the LAN IP. The verification
+# step will report a failure, but the gateway IS running on the LAN IP — the
 # health check (step 6) is the authoritative check. Do NOT exit on this false failure.
 OPENCLAW_ONBOARD_OUT=$(openclaw onboard \\
   --non-interactive \\
@@ -149,9 +155,11 @@ OPENCLAW_EXIT=$?
 ONBOARD_TAIL=$(echo "$OPENCLAW_ONBOARD_OUT" | tail -10 | tr '\\n' '|')
 echo "[startup] openclaw onboard exit: $OPENCLAW_EXIT — $ONBOARD_TAIL"
 
-# ── 5b. Inject Tool Gateway proxy into openclaw systemd service ───────────────
+# ── 5b. Inject Tool Gateway proxy + gateway host into openclaw systemd service ──
 # Find the openclaw gateway systemd service and add HTTP_PROXY so the running
 # daemon routes its LLM API calls through the Tool Gateway for metering/allowlisting.
+# Also re-inject OPENCLAW_GATEWAY_HOST so the service keeps binding to the LAN IP
+# after restart (env vars from the parent shell are not inherited by systemd units).
 OPENCLAW_SERVICE=$(systemctl list-units --type=service --all --no-legend 2>/dev/null \\
   | awk '{print $1}' | grep -i openclaw | head -1 || true)
 if [[ -n "$OPENCLAW_SERVICE" ]]; then
@@ -160,6 +168,8 @@ if [[ -n "$OPENCLAW_SERVICE" ]]; then
   mkdir -p "$SVCDIR"
   cat > "\${SVCDIR}/proxy.conf" << 'SVCEOF'
 [Service]
+Environment="OPENCLAW_GATEWAY_HOST=INTERNAL_IP_PLACEHOLDER"
+Environment="OPENCLAW_GATEWAY_PORT=GW_PORT_PLACEHOLDER"
 Environment="HTTP_PROXY=TOOL_GATEWAY_PLACEHOLDER"
 Environment="HTTPS_PROXY=TOOL_GATEWAY_PLACEHOLDER"
 Environment="NO_PROXY=metadata.google.internal,169.254.169.254,localhost,127.0.0.1,INTERNAL_IP_PLACEHOLDER"
@@ -167,9 +177,10 @@ SVCEOF
   # Replace placeholders with actual values (heredoc can't expand vars when quoted)
   sed -i "s|TOOL_GATEWAY_PLACEHOLDER|$TOOL_GATEWAY_URL|g" "\${SVCDIR}/proxy.conf"
   sed -i "s|INTERNAL_IP_PLACEHOLDER|$INTERNAL_IP|g" "\${SVCDIR}/proxy.conf"
+  sed -i "s|GW_PORT_PLACEHOLDER|$GATEWAY_PORT|g" "\${SVCDIR}/proxy.conf"
   systemctl daemon-reload
   systemctl restart "$OPENCLAW_SERVICE" || true
-  echo "[startup] Proxy injected and service restarted: $OPENCLAW_SERVICE"
+  echo "[startup] Proxy + gateway host injected and service restarted: $OPENCLAW_SERVICE"
 else
   echo "[startup] WARNING: No openclaw systemd service found — proxy not injected (LLM calls unmetered)"
 fi

--- a/services/execution-service/src/routes/bots.ts
+++ b/services/execution-service/src/routes/bots.ts
@@ -5,7 +5,7 @@ import { eq, gt, and, desc, inArray, sql } from 'drizzle-orm';
 import { computeBotMetrics } from '../performance/metrics-computer';
 import { PubSub } from '@google-cloud/pubsub';
 import { randomUUID } from 'node:crypto';
-import { getBot } from '../orchestrator/bot-registry';
+import { getBot, unregisterBot } from '../orchestrator/bot-registry';
 import { OpenClawClient } from '../orchestrator/openclaw-client';
 import { publishBotStarted } from '../events/publisher';
 
@@ -546,7 +546,8 @@ export const botsRoutes: FastifyPluginAsyncTypebox = async (fastify) => {
 
     // ── Failure payload path ─────────────────────────────────────────────────
     // The startup script encountered an error and reported back.
-    // Write errorMessage + set status to failed. Return 200 to acknowledge receipt.
+    // Write errorMessage + set status to failed. Remove from registry so the
+    // spawn timeout checker doesn't overwrite this error with a generic timeout message.
     if (body.success === false) {
       console.error('[bots/ready] Bot VM startup script reported failure:', {
         botId,
@@ -560,6 +561,9 @@ export const botsRoutes: FastifyPluginAsyncTypebox = async (fastify) => {
           updatedAt: new Date(),
         })
         .where(eq(bots.id, botId));
+      // Remove from in-memory registry so spawn timeout checker doesn't
+      // overwrite the actual error message with a generic "Spawn timeout" message.
+      unregisterBot(botId);
       return reply.code(200).send({ ok: true });
     }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `openclaw onboard --gateway-bind lan` binds the gateway to loopback (127.0.0.1) rather than the LAN interface, so the execution-service can never reach port 18789 on bot VMs over the VPC network. Every bot was failing with "OpenClaw Gateway did not become healthy within 120s".
- **Fix**: Export `OPENCLAW_GATEWAY_HOST=$INTERNAL_IP` before `openclaw onboard` (restoring the approach from the original Terraform startup script). Also inject `OPENCLAW_GATEWAY_HOST` + `OPENCLAW_GATEWAY_PORT` into the systemd service drop-in so the LAN binding persists after the service is restarted in step 5b.
- **Secondary fix**: `POST /bots/:botId/ready` failure handler now calls `unregisterBot()` after writing the real error to the DB, preventing the spawn timeout checker from overwriting it with a generic "Spawn timeout — VM did not call /ready within 10m" message 10 minutes later.

## How it was diagnosed

- Confirmed via `nc` from the app VM: port 18789 showed **connection refused** (not timeout) on all bot VMs — nothing listening on the LAN interface.
- Execution service logs showed the failure chain: `openclaw onboard` completing, then gateway health check failing for 120s, then `post_failure` correctly reporting back — but the error being silently overwritten by the spawn timeout checker.

## Test plan

- [ ] Trigger a new execution and confirm bots transition from `spawning` → `idle` (no longer timing out)
- [ ] Confirm port 18789 is reachable on a new bot VM from the app VM: `nc -zv <bot-internal-ip> 18789`
- [ ] Confirm bot failure errors (if any) show the real reason, not the generic spawn timeout message