### PR TITLE
fix(execution): populate tool_invocations from OpenClaw SSE stream

### DIFF
--- a/services/execution-service/src/orchestrator/openclaw-client.ts
+++ b/services/execution-service/src/orchestrator/openclaw-client.ts
@@ -9,6 +9,22 @@ const RECONNECT_DELAY_MS = 2_000;
 const CONNECT_TIMEOUT_MS = 15_000;
 
 // ──────────────────────────────────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────────────────────────────────
+
+export interface ToolInvocationEvent {
+  callId: string;
+  toolName: string;
+  arguments: string;
+  invokedAt: Date;
+}
+
+export interface TaskResult {
+  text: string;
+  usage?: { input_tokens: number; output_tokens: number; total_tokens: number };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
 // OpenClawClient — HTTP-based client for the OpenClaw Gateway
 // ──────────────────────────────────────────────────────────────────────────────
 
@@ -28,8 +44,9 @@ const CONNECT_TIMEOUT_MS = 15_000;
  *   client.onError((e) => ...);
  */
 export class OpenClawClient {
-  private completionCallbacks: Array<(result: string) => void> = [];
+  private completionCallbacks: Array<(result: TaskResult) => void> = [];
   private failureCallbacks: Array<(error: string) => void> = [];
+  private toolInvocationCallbacks: Array<(event: ToolInvocationEvent) => void> = [];
   private _isConnected = false;
 
   constructor(
@@ -121,7 +138,7 @@ export class OpenClawClient {
     this.executeTask(taskDescription, sessionId).catch((err: unknown) => {
       const message = err instanceof Error ? err.message : String(err);
       console.error('[openclaw-client] Task failed:', { sessionId, error: message });
-      this.failureCallbacks.forEach((cb) => cb(message));
+      for (const cb of this.failureCallbacks) cb(message);
       this.failureCallbacks = [];
     });
 
@@ -166,20 +183,22 @@ export class OpenClawClient {
 
     console.log('[openclaw-client] Task complete:', {
       sessionId,
-      resultPreview: result.slice(0, 80),
+      resultPreview: result.text.slice(0, 80),
+      usage: result.usage,
     });
-    this.completionCallbacks.forEach((cb) => cb(result));
+    for (const cb of this.completionCallbacks) cb(result);
     this.completionCallbacks = [];
   }
 
   /**
    * Parse an SSE stream from /v1/responses.
-   * Returns the text result on `response.completed`, throws on `response.failed`.
+   * Returns the text result + usage on `response.completed`, throws on `response.failed`.
+   * Fires `toolInvocationCallbacks` for each `response.output_item.done` with type `function_call`.
    */
   private async readSSEStream(
     body: ReadableStream<Uint8Array>,
     sessionId: string,
-  ): Promise<string> {
+  ): Promise<TaskResult> {
     const reader = body.getReader();
     const decoder = new TextDecoder();
     let buffer = '';
@@ -211,7 +230,32 @@ export class OpenClawClient {
 
             if (data === '[DONE]') {
               console.log('[openclaw-client] SSE stream ended with [DONE]:', { sessionId });
-              return 'Task completed';
+              return { text: 'Task completed' };
+            }
+
+            // Capture completed function_call output items → tool invocation events
+            if (currentEventType === 'response.output_item.done') {
+              try {
+                const parsed = JSON.parse(data) as {
+                  item?: { type?: string; name?: string; call_id?: string; arguments?: string };
+                };
+                if (parsed.item?.type === 'function_call' && parsed.item.call_id) {
+                  const event: ToolInvocationEvent = {
+                    callId: parsed.item.call_id,
+                    toolName: parsed.item.name ?? 'unknown',
+                    arguments: parsed.item.arguments ?? '',
+                    invokedAt: new Date(),
+                  };
+                  console.log('[openclaw-client] Tool invocation captured:', { sessionId, toolName: event.toolName, callId: event.callId });
+                  for (const cb of this.toolInvocationCallbacks) {
+                    try { cb(event); } catch (cbErr) {
+                      console.error('[openclaw-client] Tool invocation callback error:', cbErr);
+                    }
+                  }
+                }
+              } catch {
+                // non-JSON or unexpected shape — skip
+              }
             }
 
             if (currentEventType === 'response.completed') {
@@ -219,6 +263,7 @@ export class OpenClawClient {
                 const parsed = JSON.parse(data) as {
                   response?: {
                     status?: string;
+                    usage?: { input_tokens?: number; output_tokens?: number; total_tokens?: number };
                     output?: Array<{
                       type: string;
                       content?: Array<{ type: string; text?: string }>;
@@ -241,11 +286,23 @@ export class OpenClawClient {
                 const messageItem = output.find((item) => item.type === 'message');
                 const text =
                   messageItem?.content?.find((c) => c.type === 'output_text' || c.type === 'text')?.text;
-                return text ?? JSON.stringify(parsed);
+
+                const usage = response?.usage;
+                const taskResult: TaskResult = {
+                  text: text ?? JSON.stringify(parsed),
+                  usage: usage?.input_tokens != null && usage?.output_tokens != null
+                    ? {
+                        input_tokens: usage.input_tokens,
+                        output_tokens: usage.output_tokens,
+                        total_tokens: usage.total_tokens ?? (usage.input_tokens + usage.output_tokens),
+                      }
+                    : undefined,
+                };
+                return taskResult;
               } catch (err) {
                 // Re-throw errors, stringify non-error parse failures
                 if (err instanceof Error) throw err;
-                return data;
+                return { text: data };
               }
             }
 
@@ -277,17 +334,21 @@ export class OpenClawClient {
 
     // Stream ended without explicit completion — treat as done
     console.warn('[openclaw-client] SSE stream ended without response.completed:', { sessionId, totalEvents: eventCount, totalBytes: rawBytesReceived });
-    return 'Task completed (stream ended)';
+    return { text: 'Task completed (stream ended)' };
   }
 
   // ── Callbacks ───────────────────────────────────────────────────────────────
 
-  onComplete(cb: (result: string) => void): void {
+  onComplete(cb: (result: TaskResult) => void): void {
     this.completionCallbacks.push(cb);
   }
 
   onError(cb: (error: string) => void): void {
     this.failureCallbacks.push(cb);
+  }
+
+  onToolInvocation(cb: (event: ToolInvocationEvent) => void): void {
+    this.toolInvocationCallbacks.push(cb);
   }
 
   // ── Lifecycle ───────────────────────────────────────────────────────────────

--- a/services/execution-service/src/queue/openclaw-dispatcher.ts
+++ b/services/execution-service/src/queue/openclaw-dispatcher.ts
@@ -1,5 +1,6 @@
+import { randomUUID } from 'node:crypto';
 import { Worker, type Job } from 'bullmq';
-import { db, bots, tasks } from '@claw/db';
+import { db, bots, tasks, toolInvocations } from '@claw/db';
 import { eq, sql } from 'drizzle-orm';
 import {
   workerConnection,
@@ -13,6 +14,7 @@ import {
 } from '../orchestrator/bot-registry';
 import { publishTaskClaimed, publishTaskCompleted } from '../events/publisher';
 import { checkExecutionCompletion } from '../orchestrator/completion-checker';
+import type { TaskResult } from '../orchestrator/openclaw-client';
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Constants
@@ -139,13 +141,27 @@ async function dispatchTaskToBot(
     console.error('[openclaw-dispatcher] Failed to publish task_claimed (non-fatal):', err.message);
   });
 
+  // Register tool invocation callback to capture tool calls into DB
+  openclawClient.onToolInvocation((event) => {
+    db.insert(toolInvocations).values({
+      executionId,
+      botId,
+      toolName: event.toolName.slice(0, 50),
+      invocationId: event.callId,
+      requestSummary: { arguments: event.arguments.slice(0, 2000) },
+      invokedAt: event.invokedAt,
+    }).catch((err: Error) => {
+      console.error('[openclaw-dispatcher] Failed to insert tool_invocation (non-fatal):', err.message);
+    });
+  });
+
   // Keep the job lock alive while waiting (renew every 20s)
   const renewInterval = setInterval(() => {
     job.extendLock(job.token!, DISPATCH_LOCK_DURATION_MS).catch(() => {});
   }, 20_000);
 
   try {
-    const result = await new Promise<string>((resolve, reject) => {
+    const result = await new Promise<TaskResult>((resolve, reject) => {
       const timeout = setTimeout(() => {
         reject(new Error(`Task execution timed out after ${TASK_EXECUTION_TIMEOUT_MS}ms`));
       }, TASK_EXECUTION_TIMEOUT_MS);
@@ -169,7 +185,7 @@ async function dispatchTaskToBot(
     // Task succeeded — update DB
     await db
       .update(tasks)
-      .set({ status: 'completed', result, updatedAt: new Date() })
+      .set({ status: 'completed', result: result.text, updatedAt: new Date() })
       .where(eq(tasks.id, taskId));
 
     await db
@@ -193,11 +209,28 @@ async function dispatchTaskToBot(
       console.error('[openclaw-dispatcher] Failed to publish task_completed (non-fatal):', err.message);
     });
 
+    // Write summary llm_call tool_invocations row with token usage
+    await db.insert(toolInvocations).values({
+      executionId,
+      botId,
+      toolName: 'llm_call',
+      invocationId: randomUUID(),
+      durationMs: Date.now() - taskStartMs,
+      promptTokens: result.usage?.input_tokens ?? null,
+      completionTokens: result.usage?.output_tokens ?? null,
+      totalTokens: result.usage?.total_tokens ?? null,
+      responseSummary: { result: result.text.slice(0, 500) },
+      invokedAt: new Date(taskStartMs),
+    }).catch((err: Error) => {
+      console.error('[openclaw-dispatcher] Failed to insert llm_call summary (non-fatal):', err.message);
+    });
+
     console.log('[openclaw-dispatcher] Round-trip complete — task sent, completed, bot released to idle:', {
       taskId,
       botId,
       executionId,
       durationMs: Date.now() - taskStartMs,
+      usage: result.usage,
     });
 
     // Check if all tasks for this execution are now done
@@ -205,7 +238,7 @@ async function dispatchTaskToBot(
       console.error('[openclaw-dispatcher] Completion check failed (non-fatal):', err.message);
     });
 
-    return result;
+    return result.text;
   } catch (err) {
     // Task failed — update DB
     await db


### PR DESCRIPTION
## Summary
- Capture `response.output_item.done` (function_call) events from the OpenClaw SSE stream and insert rows into `tool_invocations` table in real-time
- Extract token usage from `response.completed` and write a summary `llm_call` row per task with prompt/completion/total tokens and duration
- Change `OpenClawClient` callback types from plain `string` to `TaskResult` (text + usage) and add `onToolInvocation` callback

## Context
The bot detail UI has empty **Step Trace** and **Process Log** sections because the `tool_invocations` table was never written to. The OpenClaw SSE stream already emits tool call events — we just weren't capturing them.

## Deploy notes
After merging, the container also needs 8 Pub/Sub env vars added (topic names with `-dev` suffix) to fix the activity feed SSE stream. That's a config-only change on claw-app-dev, no code needed.

## Test plan
- [ ] Trigger an execution with a tool-using task (e.g. web search)
- [ ] Verify `tool_invocations` rows appear in DB during execution
- [ ] Verify `llm_call` summary row appears after task completion with token counts
- [ ] Check `GET /bots/:botId/detail` returns populated `steps[]`
- [ ] Check bot detail UI shows Step Trace and Process Log

🤖 Generated with [Claude Code](https://claude.com/claude-code)