### PR TITLE
fix: full platform audit — security, integration, validation, and UX fixes

### DIFF
--- a/services/execution-service/.env.example
+++ b/services/execution-service/.env.example
@@ -1,3 +1,43 @@
-# Auth.js shared secret — must match exactly what services/ui uses
-# The execution-service uses this to verify Auth.js session tokens
-AUTH_SECRET=your-secret-here
+# Execution Service — required environment variables
+# All vars listed as "Required" MUST be set before starting the service.
+
+# Required
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/clawdb
+REDIS_URL=redis://localhost:6379
+AUTH_SECRET=your-secret-here  # Must match UI's AUTH_SECRET
+
+# Optional (defaults shown)
+PORT=3001
+LOG_LEVEL=info
+CORS_ORIGIN=http://localhost:5173
+
+# GCP — required in production (NODE_ENV=production)
+GCP_PROJECT_ID=claw-local
+GCP_ZONE=us-central1-a
+GCP_NETWORK=default
+GCP_SUBNET=default
+GCP_BOT_SERVICE_ACCOUNT=bot-vm@your-project.iam.gserviceaccount.com
+LLM_API_KEY_SECRET_NAME=llm-api-key
+
+# Bot auth
+BOT_JWT_SECRET=your-bot-jwt-secret
+
+# Tool Gateway URL (injected into bot VMs as HTTP_PROXY)
+TOOL_GATEWAY_VPC_URL=http://10.0.0.3:3002
+
+# Pub/Sub topics (optional — defaults to standard names)
+BOT_LIFECYCLE_TOPIC=bot-lifecycle
+TASK_LIFECYCLE_TOPIC=task-lifecycle
+GUARDRAIL_EVENTS_TOPIC=guardrail-events
+
+# Timeouts (milliseconds)
+BOT_WAIT_TIMEOUT_MS=600000
+TASK_EXECUTION_TIMEOUT_MS=1800000
+
+# Billing rates (cents per unit)
+LLM_INPUT_RATE_CENTS_PER_M=300
+LLM_OUTPUT_RATE_CENTS_PER_M=1500
+BOT_HOURLY_RATE_CENTS=50
+
+# Optional: bypass auth for CLI testing (not for production)
+# INTERNAL_API_KEY=

--- a/services/execution-service/src/main.ts
+++ b/services/execution-service/src/main.ts
@@ -1,4 +1,37 @@
 import 'dotenv/config';
+
+// ── Startup env var validation ───────────────────────────────────────────────
+const REQUIRED_ENV = [
+  'DATABASE_URL',
+  'REDIS_URL',
+  'AUTH_SECRET',
+] as const;
+
+const REQUIRED_PRODUCTION_ENV = [
+  'GCP_PROJECT_ID',
+  'GCP_ZONE',
+  'GCP_NETWORK',
+  'GCP_SUBNET',
+  'BOT_JWT_SECRET',
+  'LLM_API_KEY_SECRET_NAME',
+  'GCP_BOT_SERVICE_ACCOUNT',
+] as const;
+
+const missing = REQUIRED_ENV.filter((key) => !process.env[key]);
+if (missing.length > 0) {
+  console.error(`[main] Missing required environment variables: ${missing.join(', ')}`);
+  process.exit(1);
+}
+
+if (process.env.NODE_ENV === 'production') {
+  const missingProd = REQUIRED_PRODUCTION_ENV.filter((key) => !process.env[key]);
+  if (missingProd.length > 0) {
+    console.error(`[main] Missing required production environment variables: ${missingProd.join(', ')}`);
+    process.exit(1);
+  }
+}
+// ─────────────────────────────────────────────────────────────────────────────
+
 import { buildApp } from './app';
 import { startGuardrailWatchdog, stopGuardrailWatchdog } from './events/guardrail-watchdog';
 import { startBillingEngine } from './events/billing-engine';

--- a/services/execution-service/src/orchestrator/gce-bot-launcher.ts
+++ b/services/execution-service/src/orchestrator/gce-bot-launcher.ts
@@ -173,7 +173,11 @@ echo "[startup] OpenClaw config written (baseUrl=https://api.anthropic.com/v1, a
 # Run the gateway in the background. 'openclaw gateway --port PORT' is the correct
 # invocation — there are no 'run', 'install', or 'start' subcommands.
 # nohup + disown keeps it alive after this script exits.
+# HTTP_PROXY routes bot egress through tool-gateway for domain filtering.
+# X-Execution-Id header enables per-execution domain allowlisting.
 ANTHROPIC_API_KEY="$LLM_API_KEY" \\
+HTTP_PROXY="$TOOL_GATEWAY_URL" \\
+HTTPS_PROXY="$TOOL_GATEWAY_URL" \\
 nohup openclaw gateway --port "$GATEWAY_PORT" \\
   &>> /var/log/openclaw-gateway.log &
 GATEWAY_PID=$!

--- a/services/execution-service/src/queue/openclaw-dispatcher.ts
+++ b/services/execution-service/src/queue/openclaw-dispatcher.ts
@@ -143,21 +143,29 @@ async function dispatchTaskToBot(
 
   // Register tool invocation callback to capture tool calls into DB
   openclawClient.onToolInvocation((event) => {
-    db.insert(toolInvocations).values({
-      executionId,
-      botId,
-      toolName: event.toolName.slice(0, 50),
-      invocationId: event.callId,
-      requestSummary: { arguments: event.arguments.slice(0, 2000) },
-      invokedAt: event.invokedAt,
-    }).catch((err: Error) => {
-      console.error('[openclaw-dispatcher] Failed to insert tool_invocation (non-fatal):', err.message);
-    });
+    const insertToolInvocation = () =>
+      db.insert(toolInvocations).values({
+        executionId,
+        botId,
+        toolName: event.toolName.slice(0, 50),
+        invocationId: event.callId,
+        requestSummary: { arguments: event.arguments.slice(0, 2000) },
+        invokedAt: event.invokedAt,
+      });
+
+    insertToolInvocation()
+      .catch(() => setTimeout(() => {
+        insertToolInvocation().catch((err: Error) => {
+          console.error('[openclaw-dispatcher] Failed to insert tool_invocation after retry:', err.message);
+        });
+      }, 1000));
   });
 
   // Keep the job lock alive while waiting (renew every 20s)
   const renewInterval = setInterval(() => {
-    job.extendLock(job.token!, DISPATCH_LOCK_DURATION_MS).catch(() => {});
+    job.extendLock(job.token!, DISPATCH_LOCK_DURATION_MS).catch((err: Error) => {
+      console.warn('[openclaw-dispatcher] Lock renewal failed:', { jobId: job.id, error: err.message });
+    });
   }, 20_000);
 
   try {
@@ -210,20 +218,26 @@ async function dispatchTaskToBot(
     });
 
     // Write summary llm_call tool_invocations row with token usage
-    await db.insert(toolInvocations).values({
-      executionId,
-      botId,
-      toolName: 'llm_call',
-      invocationId: randomUUID(),
-      durationMs: Date.now() - taskStartMs,
-      promptTokens: result.usage?.input_tokens ?? null,
-      completionTokens: result.usage?.output_tokens ?? null,
-      totalTokens: result.usage?.total_tokens ?? null,
-      responseSummary: { result: result.text.slice(0, 500) },
-      invokedAt: new Date(taskStartMs),
-    }).catch((err: Error) => {
-      console.error('[openclaw-dispatcher] Failed to insert llm_call summary (non-fatal):', err.message);
-    });
+    const insertLlmSummary = () =>
+      db.insert(toolInvocations).values({
+        executionId,
+        botId,
+        toolName: 'llm_call',
+        invocationId: randomUUID(),
+        durationMs: Date.now() - taskStartMs,
+        promptTokens: result.usage?.input_tokens ?? null,
+        completionTokens: result.usage?.output_tokens ?? null,
+        totalTokens: result.usage?.total_tokens ?? null,
+        responseSummary: { result: result.text.slice(0, 500) },
+        invokedAt: new Date(taskStartMs),
+      });
+
+    insertLlmSummary()
+      .catch(() => setTimeout(() => {
+        insertLlmSummary().catch((err: Error) => {
+          console.error('[openclaw-dispatcher] Failed to insert llm_call summary after retry:', err.message);
+        });
+      }, 1000));
 
     console.log('[openclaw-dispatcher] Round-trip complete — task sent, completed, bot released to idle:', {
       taskId,

--- a/services/execution-service/src/routes/billing.ts
+++ b/services/execution-service/src/routes/billing.ts
@@ -14,6 +14,7 @@ export const billingRoutes: FastifyPluginAsyncTypebox = async (fastify) => {
             executionId: Type.String({ format: 'uuid' }),
             objective: Type.String(),
             status: Type.Union([
+              Type.Literal('pre_flight'),
               Type.Literal('queued'),
               Type.Literal('running'),
               Type.Literal('paused'),

--- a/services/execution-service/src/services/soul-library-search.ts
+++ b/services/execution-service/src/services/soul-library-search.ts
@@ -109,7 +109,7 @@ export async function searchSoulLibrary(params: SoulSearchParams): Promise<SoulS
       bs.task_category,
       bs.dimensions,
       ac.current_class,
-      (1 - (bs.embedding <=> ${sql.raw(`'${embeddingVector}'::vector`)})) AS similarity_score
+      (1 - (bs.embedding <=> ${embeddingVector}::vector)) AS similarity_score
     FROM ${botSouls} bs
     LEFT JOIN ${negativeSignalRegister} nsr
       ON nsr.soul_id = bs.id
@@ -120,7 +120,7 @@ export async function searchSoulLibrary(params: SoulSearchParams): Promise<SoulS
       bs.embedding IS NOT NULL
       AND bs.is_archetype = FALSE
       AND bs.task_category = ${taskCategory}
-      AND (1 - (bs.embedding <=> ${sql.raw(`'${embeddingVector}'::vector`)})) >= ${SOUL_SEARCH_SIMILARITY_THRESHOLD}
+      AND (1 - (bs.embedding <=> ${embeddingVector}::vector)) >= ${SOUL_SEARCH_SIMILARITY_THRESHOLD}
       AND nsr.id IS NULL
     ORDER BY similarity_score DESC
   `);
@@ -208,7 +208,7 @@ export async function searchSoulLibrary(params: SoulSearchParams): Promise<SoulS
       const lineageResult = await db.execute<LineageRow>(sql`
         SELECT parent_soul_id, COUNT(*)::int AS sibling_count
         FROM ${botSouls}
-        WHERE parent_soul_id = ANY(${sql.raw(`ARRAY[${uniqueParentIds.map((id) => `'${id}'`).join(',')}]::uuid[]`)})
+        WHERE parent_soul_id = ANY(${uniqueParentIds}::uuid[])
           AND is_archetype = FALSE
         GROUP BY parent_soul_id
       `);

--- a/services/tool-gateway/.env.example
+++ b/services/tool-gateway/.env.example
@@ -1,0 +1,16 @@
+# Tool Gateway — HTTP forward proxy for bot VM egress
+# Required
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/clawdb
+REDIS_URL=redis://localhost:6379
+
+# Optional
+PORT=3002
+LOG_LEVEL=info
+
+# Comma-separated domain allowlist for bot egress.
+# Empty = allow all (development only; restrict in production).
+# Example: api.anthropic.com,api.openai.com,generativelanguage.googleapis.com
+PROXY_DOMAIN_ALLOWLIST=
+
+# JWT secret for bot authentication (must match execution-service BOT_JWT_SECRET)
+BOT_JWT_SECRET=

--- a/services/tool-gateway/src/main.ts
+++ b/services/tool-gateway/src/main.ts
@@ -1,4 +1,19 @@
 import 'dotenv/config';
+
+// ── Startup env var validation ───────────────────────────────────────────────
+const REQUIRED_ENV = ['DATABASE_URL', 'REDIS_URL'] as const;
+
+const missing = REQUIRED_ENV.filter((key) => !process.env[key]);
+if (missing.length > 0) {
+  console.error(`[tool-gateway] Missing required environment variables: ${missing.join(', ')}`);
+  process.exit(1);
+}
+
+if (!process.env.PROXY_DOMAIN_ALLOWLIST && process.env.NODE_ENV === 'production') {
+  console.warn('[tool-gateway] PROXY_DOMAIN_ALLOWLIST is not set — all domains will be allowed. This is unsafe for production.');
+}
+// ─────────────────────────────────────────────────────────────────────────────
+
 import { buildApp } from './app';
 
 const app = await buildApp();

--- a/services/tool-gateway/src/routes/proxy.ts
+++ b/services/tool-gateway/src/routes/proxy.ts
@@ -39,7 +39,10 @@ import { getExecutionAllowedDomains } from '../services/domain-allowlist';
 const PROXY_DOMAIN_ALLOWLIST: string[] =
   (process.env.PROXY_DOMAIN_ALLOWLIST ?? '').split(',').map((d) => d.trim()).filter(Boolean);
 
+const VALID_HOSTNAME_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i;
+
 function isDomainAllowed(hostname: string, perExecutionDomains?: string[] | null): boolean {
+  if (!hostname || !VALID_HOSTNAME_RE.test(hostname)) return false;
   const allowlist = perExecutionDomains ?? PROXY_DOMAIN_ALLOWLIST;
   if (allowlist.length === 0) return true; // allow all if unconfigured
   return allowlist.some(
@@ -69,7 +72,14 @@ async function handleConnect(
     return;
   }
 
-  const executionId = req.headers['x-execution-id'] as string | undefined;
+  // Check for execution ID in header or Proxy-Authorization (encoded as "exec:<id>")
+  let executionId = req.headers['x-execution-id'] as string | undefined;
+  if (!executionId) {
+    const proxyAuth = req.headers['proxy-authorization'] as string | undefined;
+    if (proxyAuth?.startsWith('exec:')) {
+      executionId = proxyAuth.slice(5);
+    }
+  }
   let perExecutionDomains: string[] | null = null;
   if (executionId) {
     try {
@@ -136,7 +146,14 @@ async function handleHttpForwardProxy(
   const hostname = targetUrl.hostname;
   const port = parseInt(targetUrl.port || '80', 10);
 
-  const executionId = req.headers['x-execution-id'] as string | undefined;
+  // Check for execution ID in header or Proxy-Authorization (encoded as "exec:<id>")
+  let executionId = req.headers['x-execution-id'] as string | undefined;
+  if (!executionId) {
+    const proxyAuth = req.headers['proxy-authorization'] as string | undefined;
+    if (proxyAuth?.startsWith('exec:')) {
+      executionId = proxyAuth.slice(5);
+    }
+  }
   let perExecutionDomains: string[] | null = null;
   if (executionId) {
     try {

--- a/services/ui/src/lib/api.ts
+++ b/services/ui/src/lib/api.ts
@@ -34,7 +34,8 @@ const BASE = import.meta.env.VITE_API_URL ?? '/api';
 async function apiFetch<T>(url: string, options?: RequestInit): Promise<T> {
   const res = await fetch(url, options);
   if (!res.ok) {
-    throw new Error(`API error ${res.status}: ${res.statusText} — ${url}`);
+    const body = await res.text().catch(() => '');
+    throw new Error(`API error ${res.status}: ${body || res.statusText} — ${url}`);
   }
   return res.json() as Promise<T>;
 }
@@ -45,7 +46,7 @@ export async function createExecution(body: {
   budgetCapCents: number;
   allowedTools: string[];
   objectiveId?: string;
-}): Promise<{ executionId: string; status: 'queued' }> {
+}): Promise<{ executionId: string; status: 'queued' | 'pre_flight' }> {
   return apiFetch(`${BASE}/executions`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -89,7 +90,7 @@ export async function getBillingSummary(): Promise<BillingSummary> {
 
 export interface AdminExecution {
   id: string;
-  status: 'queued' | 'running' | 'paused' | 'stopped' | 'completed' | 'failed';
+  status: 'queued' | 'pre_flight' | 'running' | 'paused' | 'stopped' | 'completed' | 'failed';
   objective: string;
   maxBots: number;
   budgetCapCents: number;

--- a/services/ui/src/lib/sse.ts
+++ b/services/ui/src/lib/sse.ts
@@ -34,8 +34,8 @@ export function connectSSE(
         const payload = JSON.parse(e.data) as Record<string, unknown>;
         const isAlert = type === 'guardrail_triggered' || type === 'budget_exceeded';
         onEvent({ ...payload, type, isAlert } as ActivityEvent);
-      } catch {
-        // ignore malformed events
+      } catch (e) {
+        console.warn('[sse] Failed to parse event:', type, e);
       }
     });
   }
@@ -68,8 +68,8 @@ export function connectBotLogs(
       try {
         const payload = JSON.parse(e.data) as Record<string, unknown>;
         onEvent({ ...payload, type } as BotLogEntry);
-      } catch {
-        // ignore malformed events
+      } catch (e) {
+        console.warn('[sse] Failed to parse event:', type, e);
       }
     });
   }
@@ -99,8 +99,8 @@ export function connectLifecycleSSE(
       try {
         const payload = JSON.parse(e.data) as Record<string, unknown>;
         onEvent({ ...payload, type } as LifecycleNotification);
-      } catch {
-        // ignore malformed events
+      } catch (e) {
+        console.warn('[sse] Failed to parse event:', type, e);
       }
     });
   }

--- a/services/ui/src/routes/+page.server.ts
+++ b/services/ui/src/routes/+page.server.ts
@@ -6,7 +6,7 @@ export const actions: Actions = {
     const formData = await event.request.formData();
     const email = (formData.get('email') as string | null)?.trim() ?? '';
 
-    if (!email || !email.includes('@')) {
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
       return fail(400, { error: 'A valid email address is required.' });
     }
 

--- a/services/ui/src/routes/admin/+page.svelte
+++ b/services/ui/src/routes/admin/+page.svelte
@@ -2,11 +2,12 @@
   import { browser } from '$app/environment';
   import { listAllExecutions, stopExecution, type AdminExecution } from '$lib/api';
 
-  const ADMIN_PASSWORD = import.meta.env.VITE_ADMIN_PASSWORD ?? 'admin';
+  const ADMIN_PASSWORD = import.meta.env.VITE_ADMIN_PASSWORD;
 
   let authenticated = $state(false);
   let passwordInput = $state('');
   let authError = $state(false);
+  let authConfigError = $state(!ADMIN_PASSWORD);
 
   let executions = $state<AdminExecution[]>([]);
   let loading = $state(true);
@@ -20,6 +21,10 @@
   });
 
   function login() {
+    if (!ADMIN_PASSWORD) {
+      authConfigError = true;
+      return;
+    }
     if (passwordInput === ADMIN_PASSWORD) {
       sessionStorage.setItem('admin_auth', 'true');
       authenticated = true;
@@ -106,7 +111,9 @@
           class:input-error={authError}
           autocomplete="current-password"
         />
-        {#if authError}
+        {#if authConfigError}
+          <p class="error-msg">Admin password not configured. Set VITE_ADMIN_PASSWORD environment variable.</p>
+        {:else if authError}
           <p class="error-msg">Incorrect password.</p>
         {/if}
         <button type="submit">Sign In</button>
@@ -180,7 +187,7 @@
                 </td>
                 <td class="col-date">{formatDate(exec.createdAt)}</td>
                 <td class="col-action">
-                  {#if exec.status === 'running' || exec.status === 'queued'}
+                  {#if exec.status === 'running' || exec.status === 'queued' || exec.status === 'pre_flight'}
                     <button
                       class="stop-btn"
                       disabled={stoppingId === exec.id}
@@ -515,6 +522,7 @@
   .status-failed    { color: var(--error);         background: var(--error-dim);  border: 1px solid var(--error); }
   .status-stopped   { color: var(--amber);         background: var(--amber-dim);  border: 1px solid var(--amber); }
   .status-paused    { color: var(--amber);         background: var(--amber-dim);  border: 1px solid var(--amber); }
+  .status-pre_flight { color: var(--text-faint);    background: var(--bg-3);       border: 1px solid var(--border); }
 
   /* Stop button — danger state uses --error */
   .stop-btn {

--- a/services/ui/src/routes/api/[...path]/+server.ts
+++ b/services/ui/src/routes/api/[...path]/+server.ts
@@ -1,0 +1,74 @@
+import type { RequestHandler } from '@sveltejs/kit';
+
+const handler: RequestHandler = async (event) => {
+  const executionServiceUrl = process.env.EXECUTION_SERVICE_URL;
+  if (!executionServiceUrl) {
+    return new Response(
+      JSON.stringify({ error: 'Server configuration error: EXECUTION_SERVICE_URL not set.' }),
+      { status: 500, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  // Extract Auth.js session token from cookies
+  // Auth.js uses 'authjs.session-token' on HTTP (dev) and '__Secure-authjs.session-token' on HTTPS (prod)
+  const sessionToken =
+    event.cookies.get('__Secure-authjs.session-token') ??
+    event.cookies.get('authjs.session-token');
+
+  // Build the target URL preserving the sub-path and query string
+  const path = event.params.path ?? '';
+  const target = new URL(`/${path}`, executionServiceUrl);
+  target.search = event.url.search;
+
+  // Forward headers that matter
+  const headers = new Headers();
+  const contentType = event.request.headers.get('content-type');
+  if (contentType) {
+    headers.set('content-type', contentType);
+  }
+  if (sessionToken) {
+    headers.set('authorization', `Bearer ${sessionToken}`);
+  }
+
+  // Stream the request body through without buffering
+  const hasBody = !['GET', 'HEAD'].includes(event.request.method);
+  const body = hasBody ? event.request.body : undefined;
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target.toString(), {
+      method: event.request.method,
+      headers,
+      body,
+      // @ts-expect-error -- Node 18+ supports duplex on RequestInit for streaming bodies
+      duplex: hasBody ? 'half' : undefined,
+    });
+  } catch {
+    return new Response(
+      JSON.stringify({ error: 'Could not reach execution service.' }),
+      { status: 503, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  // Stream the response back without buffering
+  const responseHeaders = new Headers();
+  const upstreamContentType = upstream.headers.get('content-type');
+  if (upstreamContentType) {
+    responseHeaders.set('content-type', upstreamContentType);
+  }
+  const contentDisposition = upstream.headers.get('content-disposition');
+  if (contentDisposition) {
+    responseHeaders.set('content-disposition', contentDisposition);
+  }
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: responseHeaders,
+  });
+};
+
+export const GET = handler;
+export const POST = handler;
+export const PUT = handler;
+export const PATCH = handler;
+export const DELETE = handler;

--- a/services/ui/src/routes/executions/[id]/+page.svelte
+++ b/services/ui/src/routes/executions/[id]/+page.svelte
@@ -226,6 +226,7 @@
       case 'failed': return 'status-failed';
       case 'paused':
       case 'stopped': return 'status-paused';
+      case 'pre_flight': return 'status-pre_flight';
       default: return 'status-queued';
     }
   }
@@ -240,7 +241,14 @@
     <p class="loading">Loading execution...</p>
   {:else if error}
     <div class="error-banner">
-      <strong>Error:</strong> {error}
+      <strong>Error:</strong>
+      {#if error.includes('404')}
+        Execution not found.
+      {:else if error.includes('403')}
+        You don't have access to this execution.
+      {:else}
+        {error}
+      {/if}
     </div>
   {:else if execution}
     <!-- Status banner (UI-03) -->
@@ -382,9 +390,9 @@
     {/if}
 
     <!-- Running bots list with links to process logs -->
-    {#if bots.length > 0}
-      <section class="bots-section">
-        <h3>Bots <span class="bots-count">({bots.length})</span></h3>
+    <section class="bots-section">
+      <h3>Bots <span class="bots-count">({bots.length})</span></h3>
+      {#if bots.length > 0}
         <div class="bots-list">
           {#each bots as bot (bot.id)}
             <a
@@ -433,8 +441,10 @@
             </a>
           {/each}
         </div>
-      </section>
-    {/if}
+      {:else}
+        <p class="empty-feed">No bots spawned yet.</p>
+      {/if}
+    </section>
 
     <SoulInspectorPanel botId={selectedBotId} onClose={() => selectedBotId = null} />
 
@@ -545,6 +555,9 @@
 
   .status-queued { border-left: 3px solid var(--text-faint); }
   .status-queued h2 { color: var(--text-muted); }
+
+  .status-pre_flight { border-left: 3px solid var(--text-faint); }
+  .status-pre_flight h2 { color: var(--text-muted); }
 
   /* ── Metrics panel ── */
   .metrics-panel {

--- a/services/ui/src/routes/new-execution/+page.server.ts
+++ b/services/ui/src/routes/new-execution/+page.server.ts
@@ -26,6 +26,9 @@ export const actions: Actions = {
 
     const maxBots = Number(formData.get('maxBots') ?? 3);
     const budgetCapDollars = Number(formData.get('budgetCapDollars') ?? 10);
+    if (budgetCapDollars < 1 || budgetCapDollars > 10000) {
+      return fail(400, { error: 'Budget must be between $1 and $10,000.' });
+    }
     const budgetCapCents = Math.round(budgetCapDollars * 100);
     const llmProvider = (formData.get('llmProvider') as string | null) ?? 'anthropic';
     const allowedDomainsRaw = (formData.get('allowedDomains') as string | null) ?? '';
@@ -33,6 +36,9 @@ export const actions: Actions = {
     const objectiveId = (formData.get('objectiveId') as string | null)?.trim() || null;
     const allowedTools = formData.getAll('allowedTools') as string[];
     const runtimeLimitMinutes = Number(formData.get('runtimeLimitMinutes') ?? 60);
+    if (runtimeLimitMinutes < 1 || runtimeLimitMinutes > 1440) {
+      return fail(400, { error: 'Runtime limit must be between 1 and 1440 minutes (24 hours).' });
+    }
     const runtimeLimitSeconds = runtimeLimitMinutes * 60;
     const campaignType = (formData.get('campaignType') as string | null) ?? 'ad_hoc';
 


### PR DESCRIPTION
## Summary

- **Security**: Fix SQL injection in soul-library-search, remove hardcoded admin password fallback (`'admin'`), add hostname format validation in proxy
- **Integration**: Create `/api/[...path]` SvelteKit proxy route (fixes all client-side API calls), inject `HTTP_PROXY` into bot VM startup scripts for per-execution domain filtering
- **Type safety**: Add `pre_flight` status to billing schema, `AdminExecution` type, `createExecution` return type
- **Validation**: Proper email regex, server-side budget ($1–$10k) and runtime limit (1–1440min) checks
- **Error handling**: Include response body in `apiFetch` errors, log SSE parse failures, add retry for tool invocation DB writes, log BullMQ lock renewal failures
- **UX**: Bots empty state, 404/403 error differentiation on execution page
- **Config**: Startup env var validation for execution-service and tool-gateway, `.env.example` files for all services

## Test plan

- [ ] Verify execution-service starts with correct env vars and fails fast when missing
- [ ] Verify tool-gateway starts and validates env vars
- [ ] Verify client-side API calls work through the new `/api/[...path]` proxy
- [ ] Verify admin page rejects login when `VITE_ADMIN_PASSWORD` is not set
- [ ] Verify email validation rejects malformed emails (e.g., `@`, `a@`, `test @x.com`)
- [ ] Verify budget and runtime limit validation on new execution form
- [ ] Verify `pre_flight` executions display correctly in billing history and admin page
- [ ] Verify SSE parse errors are logged to console
- [ ] Verify bots section shows empty state when no bots exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)