### PR TITLE
feat(evolution): add learned_skills table for skill learning pipeline

### DIFF
--- a/packages/db/migrations/0019_learned_skills.sql
+++ b/packages/db/migrations/0019_learned_skills.sql
@@ -1,0 +1,34 @@
+-- Migration: 0019_learned_skills
+-- Creates the learned_skills table for agent-discovered procedural knowledge
+-- from decision trace analysis (Karpathy Loop skill extraction).
+
+DO $$ BEGIN
+  CREATE TYPE "skill_approval_status" AS ENUM ('auto_approved', 'pending_review', 'rejected');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "learned_skills" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "bot_id" uuid NOT NULL REFERENCES "bots"("id") ON DELETE CASCADE,
+  "soul_id" uuid,
+  "execution_id" uuid NOT NULL REFERENCES "executions"("id") ON DELETE CASCADE,
+  "name" varchar(255) NOT NULL,
+  "category" varchar(100) NOT NULL,
+  "trigger_patterns" jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "procedural_body" text NOT NULL,
+  "required_tools" jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "confidence_score" numeric(4, 3) NOT NULL,
+  "approval_status" "skill_approval_status" NOT NULL DEFAULT 'pending_review',
+  "source_trace_ids" jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "skill_content" text NOT NULL,
+  "created_at" timestamp(3) with time zone NOT NULL DEFAULT now(),
+  "approved_at" timestamp(3) with time zone,
+  "approved_by" text
+);
+
+CREATE INDEX IF NOT EXISTS "learned_skills_bot_id_idx" ON "learned_skills" ("bot_id");
+CREATE INDEX IF NOT EXISTS "learned_skills_soul_id_idx" ON "learned_skills" ("soul_id");
+CREATE INDEX IF NOT EXISTS "learned_skills_execution_id_idx" ON "learned_skills" ("execution_id");
+CREATE INDEX IF NOT EXISTS "learned_skills_approval_status_idx" ON "learned_skills" ("approval_status");
+CREATE INDEX IF NOT EXISTS "learned_skills_category_idx" ON "learned_skills" ("category");

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -23,3 +23,4 @@ export * from "./skill-activations";
 export * from "./evolution-campaigns";
 export * from "./user-preferences";
 export * from "./api-keys";
+export * from "./learned-skills";

--- a/packages/db/src/schema/learned-skills.ts
+++ b/packages/db/src/schema/learned-skills.ts
@@ -1,0 +1,64 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  text,
+  numeric,
+  jsonb,
+  timestamp,
+  index,
+  pgEnum,
+} from 'drizzle-orm/pg-core';
+import { bots } from './bots';
+import { executions } from './executions';
+
+export const skillApprovalStatusEnum = pgEnum('skill_approval_status', [
+  'auto_approved',
+  'pending_review',
+  'rejected',
+]);
+
+/**
+ * Stores skills autonomously learned by agents from decision trace analysis.
+ *
+ * Distinct from the `skills` table (user-created CRUD skills) and `agent_skills`
+ * (company-authored skill definitions). This table captures procedural knowledge
+ * that agents discover through the Karpathy Loop.
+ *
+ * Uses logical FK for soulId to avoid circular TS inference at module load time.
+ */
+export const learnedSkills = pgTable(
+  'learned_skills',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    botId: uuid('bot_id')
+      .notNull()
+      .references(() => bots.id, { onDelete: 'cascade' }),
+    soulId: uuid('soul_id'), // logical FK to bot_souls — no references() to avoid circular TS inference
+    executionId: uuid('execution_id')
+      .notNull()
+      .references(() => executions.id, { onDelete: 'cascade' }),
+    name: varchar('name', { length: 255 }).notNull(),
+    category: varchar('category', { length: 100 }).notNull(),
+    triggerPatterns: jsonb('trigger_patterns').notNull().default([]),
+    proceduralBody: text('procedural_body').notNull(),
+    requiredTools: jsonb('required_tools').notNull().default([]),
+    confidenceScore: numeric('confidence_score', { precision: 4, scale: 3 }).notNull(),
+    approvalStatus: skillApprovalStatusEnum('approval_status').notNull().default('pending_review'),
+    sourceTraceIds: jsonb('source_trace_ids').notNull().default([]),
+    skillContent: text('skill_content').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, precision: 3 }).notNull().defaultNow(),
+    approvedAt: timestamp('approved_at', { withTimezone: true, precision: 3 }),
+    approvedBy: text('approved_by'),
+  },
+  (t) => [
+    index('learned_skills_bot_id_idx').on(t.botId),
+    index('learned_skills_soul_id_idx').on(t.soulId),
+    index('learned_skills_execution_id_idx').on(t.executionId),
+    index('learned_skills_approval_status_idx').on(t.approvalStatus),
+    index('learned_skills_category_idx').on(t.category),
+  ],
+);
+
+export type LearnedSkill = typeof learnedSkills.$inferSelect;
+export type NewLearnedSkill = typeof learnedSkills.$inferInsert;

--- a/packages/event-schemas/src/skill-events.ts
+++ b/packages/event-schemas/src/skill-events.ts
@@ -1,5 +1,21 @@
 import { z } from 'zod';
 
+export const skillLearnedEventSchema = z.object({
+  type: z.literal('skill_learned'),
+  skillId: z.uuid(),
+  botId: z.uuid(),
+  executionId: z.uuid(),
+  soulId: z.string().nullable(),
+  taskCategory: z.string(),
+  skillName: z.string(),
+  confidenceScore: z.number().min(0).max(1),
+  approvalStatus: z.enum(['auto_approved', 'pending_review', 'rejected']),
+  sourceTraceIds: z.array(z.string()),
+  timestamp: z.iso.datetime(),
+});
+
+export type SkillLearnedEvent = z.infer<typeof skillLearnedEventSchema>;
+
 export const skillUnlearnedEventSchema = z.object({
   type: z.literal('skill_unlearned'),
   botId: z.uuid(),

--- a/services/akasa-server/src/god-layer/god-layer-handler.ts
+++ b/services/akasa-server/src/god-layer/god-layer-handler.ts
@@ -64,7 +64,9 @@ const MAINTAIN_DNA_CAPTURE_THRESHOLD = 0.7;
  * 6. If Promote or Maintain with compositeScore >= 0.7: capture DNA.
  * 7. If Demote, Monitor, or Retire: record negative signal.
  * 8. If Promote: check and record pioneer.
- * 9. Mark verdict as processed (godLayerProcessedAt = now).
+ * 9. If Promote or Maintain: extract learned skills from decision traces.
+ * 10. Process skill unlearning for negative verdicts.
+ * 11. Mark verdict as processed (godLayerProcessedAt = now).
  *
  * All sub-calls are wrapped in individual try/catch — one failure does not
  * block the whole God Layer.
@@ -248,7 +250,28 @@ export async function executeGodLayer(verdictId: string): Promise<GodLayerResult
     }
   }
 
-  // Step 10: Skill unlearning - track consecutiveNegativeCount and auto-remove underperforming skills
+  // Step 10: Skill learning — extract novel procedural knowledge from decision traces
+  if (verdict.verdictType === 'Promote' || verdict.verdictType === 'Maintain') {
+    try {
+      const { processSkillLearningForExecution } = await import('../services/skill-learning.js');
+      const learningResult = await processSkillLearningForExecution(
+        verdict.executionId,
+        verdict.botId,
+        verdict.soulId,
+      );
+      if (learningResult.skillsCreated > 0) {
+        console.log('[god-layer] Skills learned:', {
+          botId: verdict.botId,
+          skillsCreated: learningResult.skillsCreated,
+          skillIds: learningResult.skillIds,
+        });
+      }
+    } catch (err) {
+      console.error('[god-layer] Skill learning failed:', { botId: verdict.botId, error: (err as Error).message });
+    }
+  }
+
+  // Step 11: Skill unlearning - track consecutiveNegativeCount and auto-remove underperforming skills
   try {
     const unlearningResult = await processSkillUnlearning(
       verdict.botId,
@@ -266,7 +289,7 @@ export async function executeGodLayer(verdictId: string): Promise<GodLayerResult
     console.error('[god-layer] Skill unlearning failed:', { botId: verdict.botId, error: (err as Error).message });
   }
 
-  // Step 11: Mark verdict as processed (idempotency stamp)
+  // Step 12: Mark verdict as processed (idempotency stamp)
   try {
     await db
       .update(councilVerdicts)

--- a/services/akasa-server/src/services/skill-learning.ts
+++ b/services/akasa-server/src/services/skill-learning.ts
@@ -1,0 +1,307 @@
+import { generateText, Output } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { z } from 'zod';
+import { db, decisionTraces, learnedSkills, botSouls } from '@claw/db';
+import { eq, and } from 'drizzle-orm';
+import type { LearnedSkill } from '@claw/db';
+import type { SkillLearnedEvent } from '@claw/event-schemas';
+
+const CONFIDENCE_APPROVAL_THRESHOLD = 0.80;
+
+const SkillCandidateSchema = z.object({
+  name: z.string().min(1).max(255),
+  category: z.string().min(1).max(100),
+  triggerPatterns: z.array(z.string()).min(1),
+  proceduralBody: z.string().min(1),
+  requiredTools: z.array(z.string()),
+  confidenceScore: z.number().min(0).max(1),
+  reasoning: z.string(),
+});
+
+export type SkillCandidate = z.infer<typeof SkillCandidateSchema>;
+
+const SKILL_LEARNING_SYSTEM = `You are a skill extraction agent. Your task is to analyze decision traces from AI agent executions and identify NOVEL procedural patterns that led to successful outcomes.
+
+A novel pattern is:
+1. A decision sequence that contributed to a successful outcome
+2. NOT already present in the agent's current skill library (if any)
+3. Generalizable enough to be reused in similar situations
+
+For each successful decision trace pattern you identify, generate a SKILL.md document with:
+- **name**: A concise, descriptive name for the skill (kebab-case, max 255 chars)
+- **category**: One of: reasoning, tool_usage, planning, communication, recovery, coordination
+- **triggerPatterns**: Array of conditions that should activate this skill (max 5)
+- **proceduralBody**: Step-by-step procedure (3-10 steps, markdown numbered list)
+- **requiredTools**: Any tools needed to execute this skill (can be empty array)
+- **confidenceScore**: Your confidence this is a real, reusable skill (0.0-1.0)
+- **reasoning**: Why this pattern is novel and how it contributed to success
+
+Be conservative — only extract skills with confidence >= 0.6. Lower confidence patterns are not worth documenting.`;
+
+function buildSkillExtractionPrompt(
+  traces: Array<{
+    decisionId: string;
+    decisionType: string;
+    directiveReferenced: string | null;
+    attributionConfidence: string | null;
+    outcome: string | null;
+    metadata: unknown;
+  }>,
+  taskCategory: string | null,
+  existingSkills: string[],
+): string {
+  const successfulTraces = traces.filter(
+    (t) => t.outcome === 'success' && parseFloat(t.attributionConfidence ?? '0') > 0.5,
+  );
+
+  const traceSummary = successfulTraces
+    .slice(0, 30)
+    .map(
+      (t, i) =>
+        `### Trace ${i + 1}: ${t.decisionId}\n` +
+        `- Type: ${t.decisionType}\n` +
+        `- Directive: ${t.directiveReferenced ?? 'None'}\n` +
+        `- Confidence: ${t.attributionConfidence ?? 'N/A'}\n` +
+        `- Outcome: ${t.outcome}\n` +
+        `- Metadata: ${JSON.stringify(t.metadata ?? {})}`,
+    )
+    .join('\n\n');
+
+  const skillsSection =
+    existingSkills.length > 0
+      ? existingSkills.map((s, i) => `${i + 1}. ${s}`).join('\n')
+      : 'No existing skills recorded.';
+
+  return `## Skill Extraction Task
+
+**Task Category:** ${taskCategory ?? 'Unknown'}
+
+### Existing Skills (for novelty check)
+${skillsSection}
+
+---
+
+### High-Confidence Successful Decision Traces
+Analyze these traces for novel procedural patterns:
+
+${traceSummary}
+
+---
+
+Based on the above traces, identify any NOVEL procedural patterns that:
+1. Led to successful outcomes
+2. Are not covered by existing skills
+3. Are generalizable enough to be reused
+
+If no novel patterns found, return empty arrays. Otherwise, generate SKILL.md candidates for each novel pattern.`;
+}
+
+async function computeAverageConfidence(
+  traceIds: string[],
+  executionId: string,
+  botId: string,
+): Promise<number> {
+  if (traceIds.length === 0) return 0;
+
+  const rows = await db
+    .select({ attributionConfidence: decisionTraces.attributionConfidence })
+    .from(decisionTraces)
+    .where(
+      and(
+        eq(decisionTraces.executionId, executionId),
+        eq(decisionTraces.botId, botId),
+      ),
+    );
+
+  const matching = rows.filter(
+    (r) => r.attributionConfidence !== null && traceIds.includes(r.decisionId),
+  );
+
+  if (matching.length === 0) return 0;
+
+  const sum = matching.reduce((acc, r) => {
+    const val = parseFloat(r.attributionConfidence ?? '0');
+    return acc + (isNaN(val) ? 0 : val);
+  }, 0);
+
+  return sum / matching.length;
+}
+
+async function getExistingSkillNames(soulId: string | null): Promise<string[]> {
+  if (!soulId) return [];
+
+  const rows = await db
+    .select({ skillContent: learnedSkills.skillContent })
+    .from(learnedSkills)
+    .where(eq(learnedSkills.soulId, soulId));
+
+  return rows.map((r) => r.skillContent);
+}
+
+async function detectNovelPatterns(
+  traces: Array<{
+    decisionId: string;
+    decisionType: string;
+    directiveReferenced: string | null;
+    attributionConfidence: string | null;
+    outcome: string | null;
+    metadata: unknown;
+  }>,
+  taskCategory: string | null,
+  soulId: string | null,
+): Promise<SkillCandidate[]> {
+  const existingSkills = await getExistingSkillNames(soulId);
+  const prompt = buildSkillExtractionPrompt(traces, taskCategory, existingSkills);
+
+  const result = await generateText({
+    model: openai('gpt-4o-mini'),
+    output: Output.object({ schema: SkillCandidateSchema.array() }),
+    system: SKILL_LEARNING_SYSTEM,
+    prompt,
+    temperature: 0.3,
+  });
+
+  if (!result.output || result.output.length === 0) {
+    return [];
+  }
+
+  return result.output.filter((c) => c.confidenceScore >= 0.6);
+}
+
+function generateSkillMarkdown(candidate: SkillCandidate): string {
+  const toolsSection =
+    candidate.requiredTools.length > 0
+      ? `## Required Tools\n${candidate.requiredTools.map((t) => `- ${t}`).join('\n')}\n`
+      : '';
+
+  return `# ${candidate.name}
+
+## Category
+${candidate.category}
+
+## Trigger Patterns
+${candidate.triggerPatterns.map((p) => `- ${p}`).join('\n')}
+
+${toolsSection}## Procedure
+${candidate.proceduralBody}
+
+## Confidence
+${candidate.confidenceScore.toFixed(3)}
+
+## Reasoning
+${candidate.reasoning}
+`;
+}
+
+export interface ProcessSkillLearningResult {
+  skillsCreated: number;
+  skillIds: string[];
+}
+
+export async function processSkillLearningForExecution(
+  executionId: string,
+  botId: string,
+  soulId: string | null,
+): Promise<ProcessSkillLearningResult> {
+  const traceRows = await db
+    .select({
+      decisionId: decisionTraces.decisionId,
+      decisionType: decisionTraces.decisionType,
+      directiveReferenced: decisionTraces.directiveReferenced,
+      attributionConfidence: decisionTraces.attributionConfidence,
+      outcome: decisionTraces.outcome,
+      metadata: decisionTraces.metadata,
+    })
+    .from(decisionTraces)
+    .where(and(eq(decisionTraces.executionId, executionId), eq(decisionTraces.botId, botId)));
+
+  if (traceRows.length === 0) {
+    return { skillsCreated: 0, skillIds: [] };
+  }
+
+  const successfulTraces = traceRows.filter(
+    (t) => t.outcome === 'success' && parseFloat(t.attributionConfidence ?? '0') > 0.5,
+  );
+
+  if (successfulTraces.length === 0) {
+    return { skillsCreated: 0, skillIds: [] };
+  }
+
+  let taskCategory: string | null = null;
+  if (soulId !== null) {
+    const soulRows = await db
+      .select({ taskCategory: botSouls.taskCategory })
+      .from(botSouls)
+      .where(eq(botSouls.id, soulId))
+      .limit(1);
+    if (soulRows.length > 0 && soulRows[0]) {
+      taskCategory = soulRows[0].taskCategory ?? null;
+    }
+  }
+
+  const candidates = await detectNovelPatterns(traceRows, taskCategory, soulId);
+
+  if (candidates.length === 0) {
+    return { skillsCreated: 0, skillIds: [] };
+  }
+
+  const insertedSkills: LearnedSkill[] = [];
+
+  for (const candidate of candidates) {
+    const traceIds = successfulTraces.map((t) => t.decisionId);
+    const avgConfidence = await computeAverageConfidence(traceIds, executionId, botId);
+    const finalConfidence = (candidate.confidenceScore + avgConfidence) / 2;
+    const approvalStatus = finalConfidence >= CONFIDENCE_APPROVAL_THRESHOLD ? 'auto_approved' : 'pending_review';
+
+    const skillMarkdown = generateSkillMarkdown({
+      ...candidate,
+      confidenceScore: finalConfidence,
+    });
+
+    const [inserted] = await db
+      .insert(learnedSkills)
+      .values({
+        botId,
+        soulId: soulId ?? undefined,
+        executionId,
+        name: candidate.name,
+        category: candidate.category,
+        triggerPatterns: candidate.triggerPatterns,
+        proceduralBody: candidate.proceduralBody,
+        requiredTools: candidate.requiredTools,
+        confidenceScore: finalConfidence.toFixed(3),
+        approvalStatus,
+        sourceTraceIds: traceIds,
+        skillContent: skillMarkdown,
+        approvedAt: approvalStatus === 'auto_approved' ? new Date() : undefined,
+      })
+      .returning();
+
+    if (inserted) {
+      insertedSkills.push(inserted);
+    }
+  }
+
+  if (insertedSkills.length > 0 && insertedSkills[0]) {
+    const event: SkillLearnedEvent = {
+      type: 'skill_learned',
+      skillId: insertedSkills[0].id,
+      botId,
+      executionId,
+      soulId,
+      taskCategory: taskCategory ?? 'unknown',
+      skillName: insertedSkills[0].name,
+      confidenceScore: parseFloat(insertedSkills[0].confidenceScore),
+      approvalStatus: insertedSkills[0].approvalStatus,
+      sourceTraceIds: insertedSkills[0].sourceTraceIds as string[],
+      timestamp: new Date().toISOString(),
+    };
+
+    console.log('[skill-learning] skill_learned event:', event);
+  }
+
+  return {
+    skillsCreated: insertedSkills.length,
+    skillIds: insertedSkills.map((s) => s.id),
+  };
+}


### PR DESCRIPTION
## Summary
- Introduces a new `learned_skills` table for agent-discovered procedural knowledge (from decision trace analysis), resolving the schema conflict with PR #137 which incorrectly reused the `skills` table
- Adds `skillLearnedEventSchema` to `@claw/event-schemas` for the skill learning event pipeline
- Adapts PR #137's skill learning service to use the new `learnedSkills` Drizzle table instead of `skills`
- Wires skill learning into the God Layer handler (step 10) via dynamic import to avoid breaking tests

## Context
PR #137 created a `skills` table for agent-learned skills, but main already has a `skills` table in `packages/db/src/schema/skills.ts` for user-created skills (CRUD). The schemas are fundamentally different -- different columns, different purposes. This PR separates them cleanly:

| Table | Purpose | Schema file |
|-------|---------|-------------|
| `skills` | User-created skills (CRUD) | `skills.ts` |
| `agent_skills` | Company-authored skill definitions | `agent-skills.ts` |
| `learned_skills` | Agent-discovered skills from decision traces | `learned-skills.ts` (new) |

## Test plan
- [ ] Run `pnpm --filter @claw/db exec drizzle-kit generate` to verify schema compiles
- [ ] Apply migration `0019_learned_skills.sql` against dev database
- [ ] Verify god-layer-handler still passes existing tests (dynamic import avoids circular deps)
- [ ] Verify `@claw/event-schemas` exports `skillLearnedEventSchema` and `SkillLearnedEvent` type

🤖 Generated with [Claude Code](https://claude.com/claude-code)