### PR TITLE
test(auth): unit tests for auth and utility modules

### DIFF
--- a/services/execution-service/src/__tests__/auth.test.ts
+++ b/services/execution-service/src/__tests__/auth.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockBetterAuth = vi.fn().mockReturnValue({
+  handler: vi.fn(),
+});
+const mockDrizzleAdapter = vi.fn().mockReturnValue({ adapter: 'drizzle' });
+
+vi.mock('better-auth', () => ({
+  betterAuth: mockBetterAuth,
+}));
+
+vi.mock('better-auth/adapters/drizzle', () => ({
+  drizzleAdapter: mockDrizzleAdapter,
+}));
+
+vi.mock('@claw/db', () => ({
+  db: { mockDb: true },
+  authUsers: { table: 'auth_users' },
+  authSessions: { table: 'auth_sessions' },
+  authAccounts: { table: 'auth_accounts' },
+  authVerifications: { table: 'auth_verifications' },
+}));
+
+describe('auth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  describe('betterAuth configuration', () => {
+    it('uses dev-secret-change-me when AUTH_SECRET is not set', async () => {
+      // AUTH_SECRET uses ?? so only undefined/missing triggers the fallback
+      delete process.env['AUTH_SECRET'];
+
+      await import('../auth.js');
+
+      expect(mockBetterAuth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          secret: 'dev-secret-change-me',
+        }),
+      );
+    });
+
+    it('uses AUTH_SECRET from environment when set', async () => {
+      vi.stubEnv('AUTH_SECRET', 'my-production-secret');
+
+      await import('../auth.js');
+
+      expect(mockBetterAuth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          secret: 'my-production-secret',
+        }),
+      );
+    });
+
+    it('sets basePath to /auth', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+
+      await import('../auth.js');
+
+      expect(mockBetterAuth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          basePath: '/auth',
+        }),
+      );
+    });
+
+    it('disables email and password auth', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+
+      await import('../auth.js');
+
+      expect(mockBetterAuth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emailAndPassword: { enabled: false },
+        }),
+      );
+    });
+  });
+
+  describe('drizzle adapter', () => {
+    it('passes db instance with pg provider and auth schema tables', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+
+      await import('../auth.js');
+
+      expect(mockDrizzleAdapter).toHaveBeenCalledWith(
+        { mockDb: true },
+        {
+          provider: 'pg',
+          schema: {
+            user: { table: 'auth_users' },
+            session: { table: 'auth_sessions' },
+            account: { table: 'auth_accounts' },
+            verification: { table: 'auth_verifications' },
+          },
+        },
+      );
+    });
+  });
+
+  describe('social providers', () => {
+    it('configures Google OAuth with environment variables', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+      vi.stubEnv('GOOGLE_CLIENT_ID', 'google-client-id-123');
+      vi.stubEnv('GOOGLE_CLIENT_SECRET', 'google-client-secret-456');
+
+      await import('../auth.js');
+
+      expect(mockBetterAuth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          socialProviders: {
+            google: {
+              clientId: 'google-client-id-123',
+              clientSecret: 'google-client-secret-456',
+            },
+          },
+        }),
+      );
+    });
+
+    it('defaults Google credentials to empty strings when env vars are missing', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+      // Do not stub GOOGLE_CLIENT_ID or GOOGLE_CLIENT_SECRET
+
+      await import('../auth.js');
+
+      expect(mockBetterAuth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          socialProviders: {
+            google: {
+              clientId: '',
+              clientSecret: '',
+            },
+          },
+        }),
+      );
+    });
+  });
+
+  describe('trusted origins', () => {
+    it('defaults to localhost:5173 when TRUSTED_ORIGINS is not set', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+
+      await import('../auth.js');
+
+      expect(mockBetterAuth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          trustedOrigins: ['http://localhost:5173'],
+        }),
+      );
+    });
+
+    it('splits comma-separated TRUSTED_ORIGINS into array', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+      vi.stubEnv('TRUSTED_ORIGINS', 'https://app.example.com, https://staging.example.com');
+
+      await import('../auth.js');
+
+      expect(mockBetterAuth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          trustedOrigins: ['https://app.example.com', 'https://staging.example.com'],
+        }),
+      );
+    });
+  });
+
+  describe('PUBLIC_URL handling', () => {
+    it('sets baseURL from PUBLIC_URL origin when provided', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+      vi.stubEnv('PUBLIC_URL', 'https://api.example.com/v1');
+
+      await import('../auth.js');
+
+      expect(mockBetterAuth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'https://api.example.com',
+        }),
+      );
+    });
+
+    it('does not set baseURL when PUBLIC_URL is not provided', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+
+      await import('../auth.js');
+
+      const config = mockBetterAuth.mock.calls[0]![0];
+      expect(config).not.toHaveProperty('baseURL');
+    });
+
+    it('disables secure cookies for HTTP PUBLIC_URL', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+      vi.stubEnv('PUBLIC_URL', 'http://localhost:3000');
+
+      await import('../auth.js');
+
+      expect(mockBetterAuth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          advanced: { useSecureCookies: false },
+        }),
+      );
+    });
+
+    it('does not disable secure cookies for HTTPS PUBLIC_URL', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+      vi.stubEnv('PUBLIC_URL', 'https://api.example.com');
+
+      await import('../auth.js');
+
+      const config = mockBetterAuth.mock.calls[0]![0];
+      expect(config).not.toHaveProperty('advanced');
+    });
+  });
+});

--- a/services/execution-service/src/__tests__/lib/resolve-model.test.ts
+++ b/services/execution-service/src/__tests__/lib/resolve-model.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const openai = vi.fn().mockReturnValue({ modelId: 'openai-model' });
+const anthropic = vi.fn().mockReturnValue({ modelId: 'anthropic-model' });
+const google = vi.fn().mockReturnValue({ modelId: 'google-model' });
+
+vi.mock('@ai-sdk/openai', () => ({ openai }));
+vi.mock('@ai-sdk/anthropic', () => ({ anthropic }));
+vi.mock('@ai-sdk/google', () => ({ google }));
+
+describe('resolve-model', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('OpenAI models', () => {
+    it('resolves gpt-4 to openai provider', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      const result = resolveModel('gpt-4');
+
+      expect(openai).toHaveBeenCalledWith('gpt-4');
+      expect(result).toEqual({ modelId: 'openai-model' });
+    });
+
+    it('resolves gpt-4o to openai provider', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      resolveModel('gpt-4o');
+
+      expect(openai).toHaveBeenCalledWith('gpt-4o');
+    });
+
+    it('resolves gpt-3.5-turbo to openai provider', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      resolveModel('gpt-3.5-turbo');
+
+      expect(openai).toHaveBeenCalledWith('gpt-3.5-turbo');
+    });
+
+    it('resolves o1 models to openai provider', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      resolveModel('o1');
+
+      expect(openai).toHaveBeenCalledWith('o1');
+    });
+
+    it('resolves o1-preview to openai provider', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      resolveModel('o1-preview');
+
+      expect(openai).toHaveBeenCalledWith('o1-preview');
+    });
+
+    it('resolves o1-mini to openai provider', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      resolveModel('o1-mini');
+
+      expect(openai).toHaveBeenCalledWith('o1-mini');
+    });
+
+    it('resolves o3 models to openai provider', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      resolveModel('o3');
+
+      expect(openai).toHaveBeenCalledWith('o3');
+    });
+
+    it('resolves o3-mini to openai provider', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      resolveModel('o3-mini');
+
+      expect(openai).toHaveBeenCalledWith('o3-mini');
+    });
+  });
+
+  describe('Anthropic models', () => {
+    it('resolves claude-3-opus to anthropic provider', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      const result = resolveModel('claude-3-opus-20240229');
+
+      expect(anthropic).toHaveBeenCalledWith('claude-3-opus-20240229');
+      expect(result).toEqual({ modelId: 'anthropic-model' });
+    });
+
+    it('resolves claude-3-sonnet to anthropic provider', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      resolveModel('claude-3-sonnet-20240229');
+
+      expect(anthropic).toHaveBeenCalledWith('claude-3-sonnet-20240229');
+    });
+
+    it('resolves claude-3-haiku to anthropic provider', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      resolveModel('claude-3-haiku-20240307');
+
+      expect(anthropic).toHaveBeenCalledWith('claude-3-haiku-20240307');
+    });
+
+    it('resolves claude-3-5-sonnet to anthropic provider', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      resolveModel('claude-3-5-sonnet-20241022');
+
+      expect(anthropic).toHaveBeenCalledWith('claude-3-5-sonnet-20241022');
+    });
+  });
+
+  describe('Google models', () => {
+    it('resolves gemini-pro to google provider', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      const result = resolveModel('gemini-pro');
+
+      expect(google).toHaveBeenCalledWith('gemini-pro');
+      expect(result).toEqual({ modelId: 'google-model' });
+    });
+
+    it('resolves gemini-1.5-pro to google provider', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      resolveModel('gemini-1.5-pro');
+
+      expect(google).toHaveBeenCalledWith('gemini-1.5-pro');
+    });
+
+    it('resolves gemini-1.5-flash to google provider', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      resolveModel('gemini-1.5-flash');
+
+      expect(google).toHaveBeenCalledWith('gemini-1.5-flash');
+    });
+  });
+
+  describe('default fallback', () => {
+    it('falls back to openai for unrecognized model names', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      const result = resolveModel('some-unknown-model');
+
+      expect(openai).toHaveBeenCalledWith('some-unknown-model');
+      expect(result).toEqual({ modelId: 'openai-model' });
+    });
+
+    it('falls back to openai for empty string', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      resolveModel('');
+
+      expect(openai).toHaveBeenCalledWith('');
+    });
+  });
+
+  describe('provider isolation', () => {
+    it('does not call anthropic or google for gpt models', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      resolveModel('gpt-4');
+
+      expect(anthropic).not.toHaveBeenCalled();
+      expect(google).not.toHaveBeenCalled();
+    });
+
+    it('does not call openai or google for claude models', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      resolveModel('claude-3-opus-20240229');
+
+      expect(openai).not.toHaveBeenCalled();
+      expect(google).not.toHaveBeenCalled();
+    });
+
+    it('does not call openai or anthropic for gemini models', async () => {
+      const { resolveModel } = await import('../../lib/resolve-model.js');
+
+      resolveModel('gemini-pro');
+
+      expect(openai).not.toHaveBeenCalled();
+      expect(anthropic).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/services/execution-service/src/__tests__/lib/verify-auth-token.test.ts
+++ b/services/execution-service/src/__tests__/lib/verify-auth-token.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const compactDecrypt = vi.fn();
+
+vi.mock('jose', () => ({
+  compactDecrypt,
+}));
+
+const hkdfSync = vi.fn().mockReturnValue(new ArrayBuffer(64));
+
+vi.mock('node:crypto', () => ({
+  default: { hkdfSync },
+  hkdfSync,
+}));
+
+describe('verify-auth-token', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  describe('header validation', () => {
+    it('returns false when Authorization header is undefined', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+      const { verifyAuthToken } = await import('../../lib/verify-auth-token.js');
+
+      const result = await verifyAuthToken(undefined);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when Authorization header does not start with Bearer', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+      const { verifyAuthToken } = await import('../../lib/verify-auth-token.js');
+
+      const result = await verifyAuthToken('Basic abc123');
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when token is empty after stripping Bearer prefix', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+      const { verifyAuthToken } = await import('../../lib/verify-auth-token.js');
+
+      const result = await verifyAuthToken('Bearer ');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('AUTH_SECRET validation', () => {
+    it('throws when AUTH_SECRET is not configured', async () => {
+      vi.stubEnv('AUTH_SECRET', '');
+      // Clear the module cache to re-evaluate with empty AUTH_SECRET
+      const { verifyAuthToken } = await import('../../lib/verify-auth-token.js');
+
+      await expect(verifyAuthToken('Bearer some-token')).rejects.toThrow(
+        'AUTH_SECRET not configured',
+      );
+    });
+  });
+
+  describe('successful decryption', () => {
+    it('returns true when decrypted payload contains email', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+      const payload = JSON.stringify({ email: 'user@example.com', sub: 'user-1' });
+      compactDecrypt.mockResolvedValue({
+        plaintext: Buffer.from(payload),
+      });
+
+      const { verifyAuthToken } = await import('../../lib/verify-auth-token.js');
+
+      const result = await verifyAuthToken('Bearer valid-jwe-token');
+
+      expect(result).toBe(true);
+      expect(hkdfSync).toHaveBeenCalledWith(
+        'sha256',
+        'test-secret',
+        'authjs.session-token',
+        'Auth.js Generated Encryption Key (authjs.session-token)',
+        64,
+      );
+    });
+
+    it('returns true when decrypted payload contains sub but no email', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+      const payload = JSON.stringify({ sub: 'user-1' });
+      compactDecrypt.mockResolvedValue({
+        plaintext: Buffer.from(payload),
+      });
+
+      const { verifyAuthToken } = await import('../../lib/verify-auth-token.js');
+
+      const result = await verifyAuthToken('Bearer valid-jwe-token');
+
+      expect(result).toBe(true);
+    });
+
+    it('tries second salt when first salt fails', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+      const payload = JSON.stringify({ email: 'user@example.com' });
+
+      // First call (dev salt) fails, second call (prod salt) succeeds
+      compactDecrypt
+        .mockRejectedValueOnce(new Error('decryption failed'))
+        .mockResolvedValueOnce({ plaintext: Buffer.from(payload) });
+
+      const { verifyAuthToken } = await import('../../lib/verify-auth-token.js');
+
+      const result = await verifyAuthToken('Bearer valid-jwe-token');
+
+      expect(result).toBe(true);
+      expect(compactDecrypt).toHaveBeenCalledTimes(2);
+      // Second call should use the prod salt
+      expect(hkdfSync).toHaveBeenCalledWith(
+        'sha256',
+        'test-secret',
+        '__Secure-authjs.session-token',
+        'Auth.js Generated Encryption Key (__Secure-authjs.session-token)',
+        64,
+      );
+    });
+  });
+
+  describe('decryption failure', () => {
+    it('returns false when both salts fail to decrypt', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+      compactDecrypt
+        .mockRejectedValueOnce(new Error('decryption failed'))
+        .mockRejectedValueOnce(new Error('decryption failed'));
+
+      const { verifyAuthToken } = await import('../../lib/verify-auth-token.js');
+
+      const result = await verifyAuthToken('Bearer invalid-jwe-token');
+
+      expect(result).toBe(false);
+      expect(compactDecrypt).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns false when decrypted payload lacks email and sub', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+      const payload = JSON.stringify({ name: 'Some User', role: 'admin' });
+      compactDecrypt.mockResolvedValue({
+        plaintext: Buffer.from(payload),
+      });
+
+      const { verifyAuthToken } = await import('../../lib/verify-auth-token.js');
+
+      const result = await verifyAuthToken('Bearer valid-jwe-token');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('HKDF key derivation', () => {
+    it('derives 64-byte key using SHA-256 with correct parameters', async () => {
+      vi.stubEnv('AUTH_SECRET', 'my-auth-secret');
+      const payload = JSON.stringify({ email: 'test@test.com' });
+      compactDecrypt.mockResolvedValue({
+        plaintext: Buffer.from(payload),
+      });
+
+      const { verifyAuthToken } = await import('../../lib/verify-auth-token.js');
+
+      await verifyAuthToken('Bearer some-token');
+
+      expect(hkdfSync).toHaveBeenCalledWith(
+        'sha256',
+        'my-auth-secret',
+        'authjs.session-token',
+        'Auth.js Generated Encryption Key (authjs.session-token)',
+        64,
+      );
+    });
+
+    it('passes derived key as Uint8Array to compactDecrypt', async () => {
+      vi.stubEnv('AUTH_SECRET', 'test-secret');
+      const keyBuffer = new ArrayBuffer(64);
+      hkdfSync.mockReturnValue(keyBuffer);
+
+      const payload = JSON.stringify({ email: 'test@test.com' });
+      compactDecrypt.mockResolvedValue({
+        plaintext: Buffer.from(payload),
+      });
+
+      const { verifyAuthToken } = await import('../../lib/verify-auth-token.js');
+
+      await verifyAuthToken('Bearer some-token');
+
+      const passedKey = compactDecrypt.mock.calls[0]![1];
+      expect(passedKey).toBeInstanceOf(Uint8Array);
+      expect(passedKey.byteLength).toBe(64);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 11 tests for `verify-auth-token` (JWE decryption, header validation, HKDF key derivation, dual-salt fallback)
- Add 20 tests for `resolve-model` (OpenAI/Anthropic/Google routing, o1/o3 models, default fallback, provider isolation)
- Add 13 tests for `auth.ts` (BetterAuth config, env-driven secrets, trusted origins, Google OAuth, PUBLIC_URL/secure cookie handling)

Total: 44 new tests, all passing. Full suite (507 tests) remains green.

Closes #55

## Test plan
- [x] All 44 new tests pass individually
- [x] Full execution-service test suite (507 tests) passes with no regressions
- [x] No source code modified — test files only

🤖 Generated with [Claude Code](https://claude.com/claude-code)