### PR TITLE
feat(billing): cost projection and burn rate forecasting

### DIFF
--- a/services/execution-service/src/app.ts
+++ b/services/execution-service/src/app.ts
@@ -18,6 +18,7 @@ import { decisionTracesRoutes } from './routes/decision-traces';
 import { negativeSignalsRoutes } from './routes/negative-signals';
 import { registerAuthRoutes } from './routes/auth';
 import { onboardingRoutes } from './routes/onboarding';
+import { costProjectionsRoutes } from './routes/cost-projections';
 import { paperclipProxyRoutes } from './routes/paperclip-proxy';
 
 export async function buildApp() {
@@ -76,6 +77,9 @@ export async function buildApp() {
 
   // Onboarding — company + agent creation via Paperclip
   app.register(onboardingRoutes, { prefix: '/onboarding' });
+
+  // Cost projections — burn rate forecasting (must register before paperclip proxy)
+  app.register(costProjectionsRoutes, { prefix: '/companies' });
 
   // Paperclip proxy — forwards company/agent/issue/chat/cost requests to Paperclip
   app.register(paperclipProxyRoutes);

--- a/services/execution-service/src/routes/cost-projections.ts
+++ b/services/execution-service/src/routes/cost-projections.ts
@@ -1,0 +1,72 @@
+import { Type } from '@sinclair/typebox';
+import type { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
+import { calculateCostProjection } from '../services/cost-projection';
+
+export const costProjectionsRoutes: FastifyPluginAsyncTypebox = async (fastify) => {
+  // GET /companies/:id/costs/projections — cost projection and forecasting based on burn rate
+  fastify.get('/:id/costs/projections', {
+    schema: {
+      params: Type.Object({
+        id: Type.String({ format: 'uuid' }),
+      }),
+      response: {
+        200: Type.Object({
+          dailyBurnRateCents: Type.Integer({ description: 'Average daily spend in cents over the last 7 days' }),
+          projectedMonthlyCostCents: Type.Integer({ description: 'Projected total cost for the current month' }),
+          daysUntilBudgetExhaustion: Type.Union([
+            Type.Integer({ description: 'Days until budget runs out at current burn rate' }),
+            Type.Null(),
+          ]),
+          trend: Type.Union([
+            Type.Literal('increasing'),
+            Type.Literal('decreasing'),
+            Type.Literal('stable'),
+          ], { description: 'Burn rate trend comparing first and second half of window' }),
+          breakdown: Type.Object({
+            llmInputTokensCents: Type.Integer(),
+            llmOutputTokensCents: Type.Integer(),
+            botHoursCents: Type.Integer(),
+            toolInvocationsCents: Type.Integer(),
+          }, { description: 'Per-dimension cost breakdown for the window period' }),
+          windowDays: Type.Integer({ description: 'Number of days in the analysis window' }),
+          dataPoints: Type.Integer({ description: 'Number of days with billing data in the window' }),
+        }),
+      },
+    },
+  }, async (request, reply) => {
+    const { id: companyId } = request.params;
+
+    // Fetch budget info from Paperclip via internal proxy
+    // We need the current budget to calculate exhaustion
+    let dailyBudgetCents: number | null = null;
+    let monthlyBudgetCents: number | null = null;
+    let monthlySpentCents = 0;
+
+    try {
+      const paperclipUrl = process.env['PAPERCLIP_URL'] ?? 'http://localhost:3100';
+      const budgetRes = await fetch(`${paperclipUrl}/api/companies/${companyId}/budgets/overview`, {
+        headers: { accept: 'application/json' },
+      });
+      if (budgetRes.ok) {
+        const budgetData = await budgetRes.json() as {
+          dailyBudgetCents?: number;
+          monthlyBudgetCents?: number;
+          monthlyTotalCents?: number;
+        };
+        dailyBudgetCents = budgetData.dailyBudgetCents ?? null;
+        monthlyBudgetCents = budgetData.monthlyBudgetCents ?? null;
+        monthlySpentCents = budgetData.monthlyTotalCents ?? 0;
+      }
+    } catch (err) {
+      console.warn('[cost-projections] Could not fetch budget overview from Paperclip:', (err as Error).message);
+    }
+
+    const projection = await calculateCostProjection(
+      dailyBudgetCents,
+      monthlyBudgetCents,
+      monthlySpentCents,
+    );
+
+    return reply.code(200).send(projection);
+  });
+};

--- a/services/execution-service/src/services/cost-projection.ts
+++ b/services/execution-service/src/services/cost-projection.ts
@@ -1,0 +1,187 @@
+import { db, billingEvents, telemetry } from '@claw/db';
+import { sql, gte, and } from 'drizzle-orm';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────────────────────────────────
+
+export type BurnTrend = 'increasing' | 'decreasing' | 'stable';
+
+export interface DimensionBreakdown {
+  llmInputTokensCents: number;
+  llmOutputTokensCents: number;
+  botHoursCents: number;
+  toolInvocationsCents: number;
+}
+
+export interface CostProjection {
+  dailyBurnRateCents: number;
+  projectedMonthlyCostCents: number;
+  daysUntilBudgetExhaustion: number | null;
+  trend: BurnTrend;
+  breakdown: DimensionBreakdown;
+  windowDays: number;
+  dataPoints: number;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Constants
+// ──────────────────────────────────────────────────────────────────────────────
+
+const WINDOW_DAYS = 7;
+const TREND_THRESHOLD = 0.10; // 10% change between halves = trend shift
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Core projection logic
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Calculate cost projections based on billing events from the last 7 days.
+ *
+ * Approach:
+ * 1. Query billing_events for tool_invoked events in the last 7 days
+ * 2. Query telemetry for bot_hours in the same window
+ * 3. Calculate daily burn rate as total spend / number of active days
+ * 4. Project monthly cost = daily burn rate * days in current month
+ * 5. Budget exhaustion = remaining budget / daily burn rate
+ * 6. Trend = compare first half vs second half of window
+ */
+export async function calculateCostProjection(
+  dailyBudgetCents: number | null,
+  monthlyBudgetCents: number | null,
+  monthlySpentCents: number,
+): Promise<CostProjection> {
+  const now = new Date();
+  const windowStart = new Date(now.getTime() - WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  const midpoint = new Date(now.getTime() - (WINDOW_DAYS / 2) * 24 * 60 * 60 * 1000);
+
+  // Query billing events in the window, grouped by day
+  const dailySpend = await db
+    .select({
+      day: sql<string>`date_trunc('day', ${billingEvents.occurredAt})::date::text`,
+      totalCents: sql<number>`cast(coalesce(sum(${billingEvents.amountCents}), 0) as int)`,
+      tokenCount: sql<number>`cast(coalesce(sum(${billingEvents.tokenCount}), 0) as int)`,
+      eventCount: sql<number>`cast(count(*) as int)`,
+    })
+    .from(billingEvents)
+    .where(
+      and(
+        gte(billingEvents.occurredAt, windowStart),
+        sql`${billingEvents.eventType} = 'tool_invoked'`,
+      ),
+    )
+    .groupBy(sql`date_trunc('day', ${billingEvents.occurredAt})::date`);
+
+  // Query bot hours in the window
+  const botHoursResult = await db
+    .select({
+      totalHours: sql<number>`cast(coalesce(sum(${telemetry.metricValue}), 0) as float)`,
+    })
+    .from(telemetry)
+    .where(
+      and(
+        gte(telemetry.computedAt, windowStart),
+        sql`${telemetry.metricName} = 'bot_hours'`,
+      ),
+    );
+
+  const totalBotHours = botHoursResult[0]?.totalHours ?? 0;
+
+  // Calculate per-dimension breakdown from billing event metadata
+  const dimensionBreakdown = await db
+    .select({
+      totalInputCents: sql<number>`cast(coalesce(sum(
+        case when ${billingEvents.metadata}->>'dimension' = 'llm_input_tokens'
+        then ${billingEvents.amountCents} else 0 end
+      ), 0) as int)`,
+      totalOutputCents: sql<number>`cast(coalesce(sum(
+        case when ${billingEvents.metadata}->>'dimension' = 'llm_output_tokens'
+        then ${billingEvents.amountCents} else 0 end
+      ), 0) as int)`,
+      totalToolCents: sql<number>`cast(coalesce(sum(
+        case when ${billingEvents.metadata}->>'dimension' = 'tool_invocations'
+          or ${billingEvents.metadata}->>'dimension' is null
+        then ${billingEvents.amountCents} else 0 end
+      ), 0) as int)`,
+    })
+    .from(billingEvents)
+    .where(
+      and(
+        gte(billingEvents.occurredAt, windowStart),
+        sql`${billingEvents.eventType} = 'tool_invoked'`,
+      ),
+    );
+
+  // Bot hours cost (using default rate from billing-engine)
+  const BOT_HOURLY_RATE_CENTS = Number(process.env.BOT_HOURLY_RATE_CENTS ?? 100);
+  const botHoursCostCents = Math.round(totalBotHours * BOT_HOURLY_RATE_CENTS);
+
+  // Total spend in window
+  const totalSpendCents = dailySpend.reduce((sum, d) => sum + d.totalCents, 0) + botHoursCostCents;
+  const dataPoints = dailySpend.length;
+
+  // Daily burn rate: total spend / window days (use actual window, not just days with data)
+  const activeDays = Math.max(dataPoints, 1);
+  const dailyBurnRateCents = Math.round(totalSpendCents / activeDays);
+
+  // Project monthly cost: daily rate * days in current month
+  const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+  const dayOfMonth = now.getDate();
+  const remainingDaysInMonth = daysInMonth - dayOfMonth;
+  const projectedMonthlyCostCents = monthlySpentCents + (dailyBurnRateCents * remainingDaysInMonth);
+
+  // Days until budget exhaustion
+  let daysUntilBudgetExhaustion: number | null = null;
+  if (monthlyBudgetCents && monthlyBudgetCents > 0 && dailyBurnRateCents > 0) {
+    const remainingBudgetCents = monthlyBudgetCents - monthlySpentCents;
+    if (remainingBudgetCents > 0) {
+      daysUntilBudgetExhaustion = Math.floor(remainingBudgetCents / dailyBurnRateCents);
+    } else {
+      daysUntilBudgetExhaustion = 0;
+    }
+  } else if (dailyBudgetCents && dailyBudgetCents > 0 && dailyBurnRateCents > 0) {
+    // Fall back to daily budget if no monthly budget set
+    // Rough estimate: remaining daily budget * 30
+    daysUntilBudgetExhaustion = dailyBurnRateCents <= dailyBudgetCents
+      ? null // Under daily budget, not exhausting
+      : 0;
+  }
+
+  // Trend detection: compare first half vs second half of window
+  const firstHalfCents = dailySpend
+    .filter((d) => new Date(d.day) < midpoint)
+    .reduce((sum, d) => sum + d.totalCents, 0);
+  const secondHalfCents = dailySpend
+    .filter((d) => new Date(d.day) >= midpoint)
+    .reduce((sum, d) => sum + d.totalCents, 0);
+
+  let trend: BurnTrend = 'stable';
+  if (firstHalfCents > 0) {
+    const changeRatio = (secondHalfCents - firstHalfCents) / firstHalfCents;
+    if (changeRatio > TREND_THRESHOLD) {
+      trend = 'increasing';
+    } else if (changeRatio < -TREND_THRESHOLD) {
+      trend = 'decreasing';
+    }
+  } else if (secondHalfCents > 0) {
+    trend = 'increasing';
+  }
+
+  const dim = dimensionBreakdown[0];
+  const breakdown: DimensionBreakdown = {
+    llmInputTokensCents: dim?.totalInputCents ?? 0,
+    llmOutputTokensCents: dim?.totalOutputCents ?? 0,
+    botHoursCents: botHoursCostCents,
+    toolInvocationsCents: dim?.totalToolCents ?? 0,
+  };
+
+  return {
+    dailyBurnRateCents,
+    projectedMonthlyCostCents,
+    daysUntilBudgetExhaustion,
+    trend,
+    breakdown,
+    windowDays: WINDOW_DAYS,
+    dataPoints,
+  };
+}

--- a/services/ui/src/lib/api.ts
+++ b/services/ui/src/lib/api.ts
@@ -223,6 +223,31 @@ export interface EvolutionCostSummary {
   avgCostPerRunCents: number;
 }
 
+// ── Cost Projections ─────────────────────────────────────────────
+
+export type BurnTrend = 'increasing' | 'decreasing' | 'stable';
+
+export interface CostProjectionBreakdown {
+  llmInputTokensCents: number;
+  llmOutputTokensCents: number;
+  botHoursCents: number;
+  toolInvocationsCents: number;
+}
+
+export interface CostProjection {
+  dailyBurnRateCents: number;
+  projectedMonthlyCostCents: number;
+  daysUntilBudgetExhaustion: number | null;
+  trend: BurnTrend;
+  breakdown: CostProjectionBreakdown;
+  windowDays: number;
+  dataPoints: number;
+}
+
+export async function getCostProjections(companyId: string): Promise<CostProjection> {
+  return apiFetch(`${BASE}/companies/${companyId}/costs/projections`);
+}
+
 // ── Companies ─────────────────────────────────────────────────────
 
 export async function getCompanies(): Promise<Company[]> {

--- a/services/ui/src/lib/components/CostProjectionCard.svelte
+++ b/services/ui/src/lib/components/CostProjectionCard.svelte
@@ -1,0 +1,299 @@
+<script lang="ts">
+  import type { CostProjection, BurnTrend } from '$lib/api';
+
+  let { projection }: { projection: CostProjection } = $props();
+
+  function formatCents(cents: number): string {
+    return `$${(cents / 100).toFixed(2)}`;
+  }
+
+  function trendLabel(t: BurnTrend): string {
+    if (t === 'increasing') return 'Increasing';
+    if (t === 'decreasing') return 'Decreasing';
+    return 'Stable';
+  }
+
+  function trendArrow(t: BurnTrend): string {
+    if (t === 'increasing') return '\u2191';
+    if (t === 'decreasing') return '\u2193';
+    return '\u2192';
+  }
+
+  let exhaustionText = $derived(
+    projection.daysUntilBudgetExhaustion === null
+      ? 'No limit'
+      : projection.daysUntilBudgetExhaustion === 0
+        ? 'Exhausted'
+        : `${projection.daysUntilBudgetExhaustion}d`
+  );
+
+  let exhaustionUrgent = $derived(
+    projection.daysUntilBudgetExhaustion !== null && projection.daysUntilBudgetExhaustion <= 3
+  );
+
+  let breakdownItems = $derived([
+    { label: 'LLM Input', cents: projection.breakdown.llmInputTokensCents },
+    { label: 'LLM Output', cents: projection.breakdown.llmOutputTokensCents },
+    { label: 'Bot Hours', cents: projection.breakdown.botHoursCents },
+    { label: 'Tool Calls', cents: projection.breakdown.toolInvocationsCents },
+  ]);
+
+  let breakdownTotal = $derived(
+    breakdownItems.reduce((sum, item) => sum + item.cents, 0)
+  );
+</script>
+
+<div class="projection-card">
+  <div class="card-header">
+    <h3 class="card-title">Cost Forecast</h3>
+    <span class="window-badge">{projection.windowDays}d window</span>
+  </div>
+
+  <div class="projection-grid">
+    <div class="projection-metric">
+      <span class="metric-label">DAILY BURN</span>
+      <span class="metric-value">{formatCents(projection.dailyBurnRateCents)}</span>
+      <span class="metric-sub">per day avg</span>
+    </div>
+
+    <div class="projection-metric">
+      <span class="metric-label">PROJECTED MONTHLY</span>
+      <span class="metric-value">{formatCents(projection.projectedMonthlyCostCents)}</span>
+      <span class="metric-sub">end of month</span>
+    </div>
+
+    <div class="projection-metric">
+      <span class="metric-label">BUDGET RUNWAY</span>
+      <span class="metric-value" class:urgent={exhaustionUrgent}>{exhaustionText}</span>
+      <span class="metric-sub">at current rate</span>
+    </div>
+
+    <div class="projection-metric">
+      <span class="metric-label">TREND</span>
+      <span class="metric-value trend-value" data-trend={projection.trend}>
+        <span class="trend-arrow">{trendArrow(projection.trend)}</span>
+        {trendLabel(projection.trend)}
+      </span>
+      <span class="metric-sub">{projection.dataPoints} data points</span>
+    </div>
+  </div>
+
+  {#if breakdownTotal > 0}
+    <div class="breakdown">
+      <span class="breakdown-heading">COST BREAKDOWN</span>
+      <div class="breakdown-bar">
+        {#each breakdownItems as item}
+          {#if item.cents > 0}
+            <div
+              class="bar-segment"
+              data-dimension={item.label}
+              style="width: {(item.cents / breakdownTotal) * 100}%"
+              title="{item.label}: {formatCents(item.cents)}"
+            ></div>
+          {/if}
+        {/each}
+      </div>
+      <div class="breakdown-legend">
+        {#each breakdownItems as item}
+          {#if item.cents > 0}
+            <span class="legend-item" data-dimension={item.label}>
+              <span class="legend-dot" data-dimension={item.label}></span>
+              {item.label} {formatCents(item.cents)}
+            </span>
+          {/if}
+        {/each}
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .projection-card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: 20px 22px;
+  }
+
+  .card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 18px;
+  }
+
+  .card-title {
+    font-family: var(--font-display);
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--ink);
+    margin: 0;
+    line-height: 1.2;
+  }
+
+  :global(body.back-office) .card-title {
+    color: var(--bo-text);
+  }
+
+  .window-badge {
+    font-family: var(--font-label);
+    font-size: 5px;
+    color: var(--text-muted);
+    letter-spacing: 0.10em;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 3px 8px;
+  }
+
+  .projection-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: var(--space-md);
+    margin-bottom: 18px;
+  }
+
+  .projection-metric {
+    min-width: 0;
+  }
+
+  .metric-label {
+    font-family: var(--font-label);
+    font-size: 5px;
+    color: var(--text-muted);
+    letter-spacing: 0.10em;
+    display: block;
+    margin-bottom: 7px;
+  }
+
+  .metric-value {
+    font-family: var(--font-label);
+    font-size: 18px;
+    color: var(--text);
+    line-height: 1;
+    display: block;
+  }
+
+  .metric-value.urgent {
+    color: #D94F3D;
+  }
+
+  .metric-sub {
+    font-family: var(--font-body);
+    font-size: 10px;
+    color: var(--text-muted);
+    display: block;
+    margin-top: 3px;
+  }
+
+  .trend-value {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .trend-arrow {
+    font-size: 14px;
+  }
+
+  .trend-value[data-trend='increasing'] {
+    color: #D94F3D;
+  }
+
+  .trend-value[data-trend='decreasing'] {
+    color: #3D8C6E;
+  }
+
+  .trend-value[data-trend='stable'] {
+    color: var(--text-muted);
+  }
+
+  .breakdown {
+    border-top: 1px solid var(--fo-border);
+    padding-top: 14px;
+  }
+
+  :global(body.back-office) .breakdown {
+    border-top-color: var(--bo-border, rgba(124, 58, 237, 0.15));
+  }
+
+  .breakdown-heading {
+    font-family: var(--font-label);
+    font-size: 5px;
+    color: var(--text-muted);
+    letter-spacing: 0.10em;
+    display: block;
+    margin-bottom: 10px;
+  }
+
+  .breakdown-bar {
+    display: flex;
+    height: 6px;
+    border-radius: 3px;
+    overflow: hidden;
+    margin-bottom: 10px;
+    background: var(--fo-bg2, #EBE8E0);
+  }
+
+  :global(body.back-office) .breakdown-bar {
+    background: rgba(124, 58, 237, 0.08);
+  }
+
+  .bar-segment {
+    min-width: 3px;
+    transition: width 0.3s ease;
+  }
+
+  .bar-segment[data-dimension='LLM Input'] {
+    background: #7C3AED;
+  }
+
+  .bar-segment[data-dimension='LLM Output'] {
+    background: #A78BFA;
+  }
+
+  .bar-segment[data-dimension='Bot Hours'] {
+    background: #D4A843;
+  }
+
+  .bar-segment[data-dimension='Tool Calls'] {
+    background: #6B7280;
+  }
+
+  .breakdown-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .legend-item {
+    font-family: var(--font-body);
+    font-size: 11px;
+    color: var(--text-muted);
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  }
+
+  .legend-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .legend-dot[data-dimension='LLM Input'] {
+    background: #7C3AED;
+  }
+
+  .legend-dot[data-dimension='LLM Output'] {
+    background: #A78BFA;
+  }
+
+  .legend-dot[data-dimension='Bot Hours'] {
+    background: #D4A843;
+  }
+
+  .legend-dot[data-dimension='Tool Calls'] {
+    background: #6B7280;
+  }
+</style>

--- a/services/ui/src/routes/(app)/sanctum/+page.server.ts
+++ b/services/ui/src/routes/(app)/sanctum/+page.server.ts
@@ -13,6 +13,7 @@ export const load: PageServerLoad = async ({ fetch, parent }) => {
     spendByAgentRes,
     spendByOpRes,
     evolutionCostRes,
+    costProjectionsRes,
   ] = await Promise.allSettled([
     fetch(`/api/companies/${companyId}/costs/summary`),
     fetch(`/api/companies/${companyId}/costs/by-agent`),
@@ -21,6 +22,7 @@ export const load: PageServerLoad = async ({ fetch, parent }) => {
     fetch(`/api/companies/${companyId}/costs/trends/by-agent`),
     fetch(`/api/companies/${companyId}/costs/trends/by-operation`),
     fetch(`/api/companies/${companyId}/costs/evolution`),
+    fetch(`/api/companies/${companyId}/costs/projections`),
   ]);
 
   const costSummary = costSummaryRes.status === 'fulfilled' && costSummaryRes.value.ok
@@ -44,6 +46,9 @@ export const load: PageServerLoad = async ({ fetch, parent }) => {
   const evolutionCosts = evolutionCostRes.status === 'fulfilled' && evolutionCostRes.value.ok
     ? await evolutionCostRes.value.json()
     : null;
+  const costProjections = costProjectionsRes.status === 'fulfilled' && costProjectionsRes.value.ok
+    ? await costProjectionsRes.value.json()
+    : null;
 
   return {
     costSummary,
@@ -53,5 +58,6 @@ export const load: PageServerLoad = async ({ fetch, parent }) => {
     spendByAgent,
     spendByOperation,
     evolutionCosts,
+    costProjections,
   };
 };

--- a/services/ui/src/routes/(app)/sanctum/+page.svelte
+++ b/services/ui/src/routes/(app)/sanctum/+page.svelte
@@ -6,6 +6,7 @@
   import StackedAreaChart from '$lib/components/StackedAreaChart.svelte';
   import OperationBreakdownChart from '$lib/components/OperationBreakdownChart.svelte';
   import CostAlertBanner from '$lib/components/CostAlertBanner.svelte';
+  import CostProjectionCard from '$lib/components/CostProjectionCard.svelte';
   import type { PageData } from './$types';
   import { subscribeWS } from '$lib/ws.js';
   import type { LiveEvent } from '$lib/ws.js';
@@ -21,21 +22,22 @@
   let spendByAgent = $derived(data.spendByAgent ?? []);
   let spendByOperation = $derived(data.spendByOperation ?? []);
   let evolutionCosts = $derived(data.evolutionCosts);
+  let costProjections = $derived(data.costProjections);
 
   function formatCents(cents: number | null | undefined): string {
-    if (cents == null) return '—';
+    if (cents == null) return '\u2014';
     return `$${(cents / 100).toFixed(2)}`;
   }
 
   function formatNumber(val: number | null | undefined): string {
-    if (val == null) return '—';
+    if (val == null) return '\u2014';
     if (val >= 1_000_000) return `${(val / 1_000_000).toFixed(1)}M`;
     if (val >= 1_000) return `${(val / 1_000).toFixed(1)}K`;
     return String(val);
   }
 
   function formatDate(iso: string | null | undefined): string {
-    if (!iso) return '—';
+    if (!iso) return '\u2014';
     return new Date(iso).toLocaleDateString([], { month: 'short', day: 'numeric' });
   }
 
@@ -46,10 +48,10 @@
     formatNumber(costSummary?.totalTokens ?? costSummary?.breakdown?.tokens as number | undefined)
   );
   let budgetRemaining = $derived(
-    budget ? formatCents(budget.remainingTodayCents) : '—'
+    budget ? formatCents(budget.remainingTodayCents) : '\u2014'
   );
   let monthlyTotal = $derived(
-    budget ? formatCents(budget.monthlyTotalCents) : '—'
+    budget ? formatCents(budget.monthlyTotalCents) : '\u2014'
   );
 
   let karmaText = $derived(
@@ -108,6 +110,12 @@
       <MetricTile label="TOKENS" value={totalTokens} />
     </div>
   </section>
+
+  {#if costProjections}
+    <section class="section projection-section" aria-label="Cost projections">
+      <CostProjectionCard projection={costProjections} />
+    </section>
+  {/if}
 
   {#if budget && companyId}
     <section class="section budget-section" aria-label="Budget controls">
@@ -258,6 +266,10 @@
   .alert-section {
     padding-top: 0;
     padding-bottom: 0;
+  }
+
+  .projection-section {
+    padding-top: 0;
   }
 
   .metric-grid {


### PR DESCRIPTION
## Summary
- Adds a cost projection service that calculates daily burn rate from a 7-day billing event window, projects end-of-month costs, estimates budget exhaustion days, and detects spend trends (increasing/decreasing/stable)
- New `GET /companies/:id/costs/projections` API endpoint with TypeBox schema validation, returning per-dimension breakdown (LLM input tokens, LLM output tokens, bot hours, tool invocations)
- New `CostProjectionCard` Svelte 5 component on the Sanctum page showing burn rate, projected monthly cost, budget runway, trend indicator, and a stacked breakdown bar

Closes #98

## Test plan
- [ ] Verify endpoint returns valid projection data with billing events in the DB
- [ ] Verify endpoint returns zero values gracefully when no billing data exists
- [ ] Verify trend detection correctly identifies increasing/decreasing/stable spend patterns
- [ ] Verify budget exhaustion calculation works with monthly budget, daily budget, and no budget
- [ ] Verify CostProjectionCard renders correctly on the Sanctum page in Screenplay theme
- [ ] Verify the projection card is hidden when no projection data is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)