### PR TITLE
feat(ui): skill management UI with library, loadout editor, effectiveness display

### DIFF
--- a/services/ui/src/lib/api.ts
+++ b/services/ui/src/lib/api.ts
@@ -492,3 +492,115 @@ export async function getEvolutionCostSummary(
 ): Promise<EvolutionCostSummary> {
   return apiFetch(`${BASE}/companies/${companyId}/costs/evolution`);
 }
+
+// ── Skills Library ───────────────────────────────────────────────
+
+export interface Skill {
+  id: string;
+  userId: string;
+  name: string;
+  description: string;
+  version: string;
+  category: string;
+  triggers: string[];
+  requiresTools: string[];
+  requiresSkills: string[];
+  minAgentClass: string;
+  content: string;
+  contentHash: string;
+  source: string;
+  isPublic: string;
+  effectivenessStats: SkillEffectivenessStats | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SkillEffectivenessStats {
+  totalActivations?: number;
+  successRate?: number;
+  avgDuration?: number;
+  lastActivatedAt?: string;
+}
+
+export interface CreateSkillInput {
+  userId: string;
+  content: string;
+  source?: 'user_created' | 'imported' | 'curated';
+  isPublic?: boolean;
+}
+
+export async function getSkills(
+  userId: string,
+  params?: { category?: string; source?: string },
+): Promise<Skill[]> {
+  const query = new URLSearchParams({ userId });
+  if (params?.category) query.set('category', params.category);
+  if (params?.source) query.set('source', params.source);
+  return apiFetch(`${BASE}/akasa/skills?${query.toString()}`);
+}
+
+export async function getSkill(skillId: string): Promise<Skill> {
+  return apiFetch(`${BASE}/akasa/skills/${skillId}`);
+}
+
+export async function createSkill(input: CreateSkillInput): Promise<Skill> {
+  return apiFetch(`${BASE}/akasa/skills`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+}
+
+export async function updateSkill(
+  skillId: string,
+  body: { content?: string; name?: string; description?: string },
+): Promise<Skill> {
+  return apiFetch(`${BASE}/akasa/skills/${skillId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+export async function deleteSkill(skillId: string): Promise<{ ok: boolean }> {
+  return apiFetch(`${BASE}/akasa/skills/${skillId}`, {
+    method: 'DELETE',
+  });
+}
+
+// ── Agent Skills (Loadout) ───────────────────────────────────────
+
+export interface EquippedSkill {
+  skillId: string;
+  equippedAt: string;
+  equippedBy: string;
+  skillName: string;
+  skillDescription: string;
+  skillCategory: string;
+  skillVersion: string;
+}
+
+export async function getAgentSkills(agentId: string): Promise<EquippedSkill[]> {
+  return apiFetch(`${BASE}/akasa/agents/${agentId}/skills`);
+}
+
+export async function equipSkill(
+  agentId: string,
+  skillId: string,
+  equippedBy: string,
+): Promise<unknown> {
+  return apiFetch(`${BASE}/akasa/agents/${agentId}/skills/${skillId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ equippedBy }),
+  });
+}
+
+export async function unequipSkill(
+  agentId: string,
+  skillId: string,
+): Promise<{ ok: boolean }> {
+  return apiFetch(`${BASE}/akasa/agents/${agentId}/skills/${skillId}`, {
+    method: 'DELETE',
+  });
+}

--- a/services/ui/src/lib/components/NavBar.svelte
+++ b/services/ui/src/lib/components/NavBar.svelte
@@ -5,7 +5,7 @@
   import { authClient } from '$lib/auth-client';
   import { browser } from '$app/environment';
 
-  let { activeTab }: { activeTab?: 'indra' | 'office' | 'chat' | 'sanctum' | 'tools' | 'evolution' } = $props();
+  let { activeTab }: { activeTab?: 'indra' | 'office' | 'chat' | 'sanctum' | 'tools' | 'skills' | 'evolution' } = $props();
 
   let isDark = $state(false);
 
@@ -25,6 +25,7 @@
     { href: '/chat',      label: 'CHAT',      key: 'chat' },
     { href: '/sanctum',   label: 'SANCTUM',   key: 'sanctum' },
     { href: '/tools',     label: 'TOOLS',     key: 'tools' },
+    { href: '/skills',   label: 'SKILLS',    key: 'skills' },
     { href: '/evolution', label: 'EVOLUTION', key: 'evolution' },
     { href: '/settings',  label: 'SETTINGS',  key: 'settings' },
   ] as const;

--- a/services/ui/src/lib/components/evolution/SkillEffectiveness.svelte
+++ b/services/ui/src/lib/components/evolution/SkillEffectiveness.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+  import type { SkillEffectivenessStats } from '$lib/api';
+
+  interface Props {
+    stats: SkillEffectivenessStats | null;
+    compact?: boolean;
+  }
+
+  let { stats, compact = false }: Props = $props();
+
+  const successPercent = $derived(
+    stats?.successRate != null ? Math.round(stats.successRate * 100) : null,
+  );
+
+  const avgDurationSec = $derived(
+    stats?.avgDuration != null ? (stats.avgDuration / 1000).toFixed(1) : null,
+  );
+
+  const lastActive = $derived.by(() => {
+    if (!stats?.lastActivatedAt) return null;
+    const d = new Date(stats.lastActivatedAt);
+    const now = Date.now();
+    const diffMs = now - d.getTime();
+    const diffH = Math.floor(diffMs / 3600000);
+    if (diffH < 1) return 'Just now';
+    if (diffH < 24) return `${diffH}h ago`;
+    const diffD = Math.floor(diffH / 24);
+    return `${diffD}d ago`;
+  });
+</script>
+
+{#if stats && stats.totalActivations != null && stats.totalActivations > 0}
+  <div class="effectiveness" class:compact>
+    <div class="stat-row">
+      <span class="stat-label">ACTIVATIONS</span>
+      <span class="stat-value">{stats.totalActivations}</span>
+    </div>
+    {#if successPercent !== null}
+      <div class="stat-row">
+        <span class="stat-label">SUCCESS</span>
+        <div class="bar-wrap">
+          <div
+            class="bar-fill"
+            class:high={successPercent >= 80}
+            class:mid={successPercent >= 50 && successPercent < 80}
+            class:low={successPercent < 50}
+            style="width: {successPercent}%"
+          ></div>
+        </div>
+        <span class="stat-value">{successPercent}%</span>
+      </div>
+    {/if}
+    {#if avgDurationSec !== null}
+      <div class="stat-row">
+        <span class="stat-label">AVG TIME</span>
+        <span class="stat-value">{avgDurationSec}s</span>
+      </div>
+    {/if}
+    {#if lastActive}
+      <div class="stat-row">
+        <span class="stat-label">LAST USED</span>
+        <span class="stat-value faint">{lastActive}</span>
+      </div>
+    {/if}
+  </div>
+{:else}
+  <div class="effectiveness empty" class:compact>
+    <span class="no-data">No activation data yet</span>
+  </div>
+{/if}
+
+<style>
+  .effectiveness {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: var(--space-sm) var(--space-md);
+    background: rgba(124, 58, 237, 0.04);
+    border: 1px solid var(--bo-border);
+    border-radius: var(--radius-md);
+  }
+
+  .effectiveness.compact {
+    padding: 4px 8px;
+    gap: 3px;
+  }
+
+  .effectiveness.empty {
+    padding: var(--space-sm) var(--space-md);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .stat-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+  }
+
+  .stat-label {
+    font-family: var(--font-label);
+    font-size: 6px;
+    letter-spacing: 0.10em;
+    color: var(--bo-faint);
+    min-width: 70px;
+    flex-shrink: 0;
+  }
+
+  .compact .stat-label {
+    min-width: 55px;
+  }
+
+  .stat-value {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--bo-text);
+  }
+
+  .stat-value.faint {
+    color: var(--bo-muted);
+  }
+
+  .bar-wrap {
+    flex: 1;
+    height: 4px;
+    background: rgba(236, 232, 255, 0.06);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  .bar-fill {
+    height: 100%;
+    border-radius: 2px;
+    transition: width 0.3s ease;
+  }
+
+  .bar-fill.high { background: var(--bo-teal); }
+  .bar-fill.mid  { background: var(--bo-amber); }
+  .bar-fill.low  { background: var(--bo-rose); }
+
+  .no-data {
+    font-size: 11px;
+    color: var(--bo-faint);
+  }
+</style>

--- a/services/ui/src/lib/components/evolution/SkillLoadout.svelte
+++ b/services/ui/src/lib/components/evolution/SkillLoadout.svelte
@@ -1,0 +1,560 @@
+<script lang="ts">
+  import {
+    getAgentSkills,
+    getSkills,
+    equipSkill,
+    unequipSkill,
+    type EquippedSkill,
+    type Skill,
+  } from '$lib/api';
+
+  interface Props {
+    botId: string;
+    userId: string;
+    agentClass: string | null;
+  }
+
+  const CAPACITY: Record<string, number> = {
+    Novice: 3,
+    Understudy: 5,
+    Artisan: 8,
+    Retired: 0,
+  };
+
+  const CATEGORY_COLORS: Record<string, string> = {
+    communication: 'var(--bo-teal)',
+    analysis: 'var(--bo-violet)',
+    creation: 'var(--bo-amber)',
+    automation: 'var(--bo-rose)',
+    research: 'var(--bo-vb)',
+    coordination: 'var(--bo-teal)',
+    monitoring: 'var(--bo-amber)',
+    other: 'var(--bo-faint)',
+  };
+
+  let { botId, userId, agentClass }: Props = $props();
+
+  let equipped = $state<EquippedSkill[]>([]);
+  let allSkills = $state<Skill[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+  let showLibrary = $state(false);
+  let filterCategory = $state<string>('');
+  let actionLoading = $state<string | null>(null);
+
+  const capacity = $derived(CAPACITY[agentClass ?? 'Novice'] ?? 3);
+  const slotsUsed = $derived(equipped.length);
+  const slotsFree = $derived(capacity - slotsUsed);
+  const equippedIds = $derived(new Set(equipped.map((s) => s.skillId)));
+
+  const availableSkills = $derived.by(() => {
+    let filtered = allSkills.filter((s) => !equippedIds.has(s.id));
+    if (filterCategory) {
+      filtered = filtered.filter((s) => s.category === filterCategory);
+    }
+    return filtered;
+  });
+
+  const categories = $derived.by(() => {
+    const cats = new Set(allSkills.map((s) => s.category));
+    return Array.from(cats).sort();
+  });
+
+  async function loadData() {
+    loading = true;
+    error = null;
+    try {
+      const [equippedRes, skillsRes] = await Promise.allSettled([
+        getAgentSkills(botId),
+        getSkills(userId),
+      ]);
+      equipped = equippedRes.status === 'fulfilled' ? equippedRes.value : [];
+      allSkills = skillsRes.status === 'fulfilled' ? skillsRes.value : [];
+    } catch (err) {
+      error = (err as Error).message;
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function handleEquip(skillId: string) {
+    if (slotsFree <= 0) return;
+    actionLoading = skillId;
+    try {
+      await equipSkill(botId, skillId, userId);
+      await loadData();
+    } catch (err) {
+      error = (err as Error).message;
+    } finally {
+      actionLoading = null;
+    }
+  }
+
+  async function handleUnequip(skillId: string) {
+    actionLoading = skillId;
+    try {
+      await unequipSkill(botId, skillId);
+      await loadData();
+    } catch (err) {
+      error = (err as Error).message;
+    } finally {
+      actionLoading = null;
+    }
+  }
+
+  $effect(() => {
+    loadData();
+  });
+</script>
+
+<div class="skill-loadout">
+  <div class="loadout-header">
+    <h3 class="loadout-title">Skill Loadout</h3>
+    <div class="slot-meter">
+      <span class="slot-label">SLOTS</span>
+      <div class="slot-bar">
+        {#each Array(capacity) as _, i}
+          <div class="slot-pip" class:filled={i < slotsUsed}></div>
+        {/each}
+      </div>
+      <span class="slot-count">{slotsUsed}/{capacity}</span>
+    </div>
+  </div>
+
+  {#if loading}
+    <div class="loading-state">
+      <span class="loading-dot"></span>
+      <span class="loading-text">Loading skills...</span>
+    </div>
+  {:else if error}
+    <div class="error-state">
+      <p class="error-text">{error}</p>
+      <button class="retry-btn" onclick={loadData}>Retry</button>
+    </div>
+  {:else}
+    <!-- Equipped Skills -->
+    <div class="equipped-section">
+      {#if equipped.length === 0}
+        <p class="empty-msg">No skills equipped. Open the library to equip skills.</p>
+      {:else}
+        <div class="equipped-list">
+          {#each equipped as skill}
+            <div class="equipped-card">
+              <div class="skill-info">
+                <span
+                  class="skill-cat-dot"
+                  style="background: {CATEGORY_COLORS[skill.skillCategory] ?? 'var(--bo-faint)'}"
+                ></span>
+                <div class="skill-meta">
+                  <span class="skill-name">{skill.skillName}</span>
+                  <span class="skill-desc">{skill.skillDescription}</span>
+                </div>
+                <span class="skill-version">v{skill.skillVersion}</span>
+              </div>
+              <button
+                class="unequip-btn"
+                disabled={actionLoading === skill.skillId}
+                onclick={() => handleUnequip(skill.skillId)}
+              >
+                {actionLoading === skill.skillId ? '...' : 'UNEQUIP'}
+              </button>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </div>
+
+    <!-- Library Toggle -->
+    <button class="library-toggle" onclick={() => (showLibrary = !showLibrary)}>
+      {showLibrary ? 'HIDE LIBRARY' : 'OPEN LIBRARY'}
+      <span class="toggle-arrow" class:open={showLibrary}></span>
+    </button>
+
+    <!-- Available Skills Library -->
+    {#if showLibrary}
+      <div class="library-section">
+        {#if categories.length > 1}
+          <div class="filter-bar">
+            <button
+              class="filter-chip"
+              class:active={filterCategory === ''}
+              onclick={() => (filterCategory = '')}
+            >ALL</button>
+            {#each categories as cat}
+              <button
+                class="filter-chip"
+                class:active={filterCategory === cat}
+                onclick={() => (filterCategory = cat)}
+              >{cat.toUpperCase()}</button>
+            {/each}
+          </div>
+        {/if}
+
+        {#if availableSkills.length === 0}
+          <p class="empty-msg">
+            {allSkills.length === 0
+              ? 'No skills in your library. Create skills from the Skills page.'
+              : 'All matching skills are already equipped.'}
+          </p>
+        {:else}
+          <div class="available-list">
+            {#each availableSkills as skill}
+              <div class="available-card">
+                <div class="skill-info">
+                  <span
+                    class="skill-cat-dot"
+                    style="background: {CATEGORY_COLORS[skill.category] ?? 'var(--bo-faint)'}"
+                  ></span>
+                  <div class="skill-meta">
+                    <span class="skill-name">{skill.name}</span>
+                    <span class="skill-desc">{skill.description}</span>
+                  </div>
+                  <span class="skill-class-badge">{skill.minAgentClass}</span>
+                </div>
+                <button
+                  class="equip-btn"
+                  disabled={slotsFree <= 0 || actionLoading === skill.id}
+                  onclick={() => handleEquip(skill.id)}
+                >
+                  {#if actionLoading === skill.id}
+                    ...
+                  {:else if slotsFree <= 0}
+                    FULL
+                  {:else}
+                    EQUIP
+                  {/if}
+                </button>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .skill-loadout {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .loadout-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-md);
+  }
+
+  .loadout-title {
+    font-family: var(--font-display);
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--bo-text);
+    margin: 0;
+  }
+
+  .slot-meter {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+  }
+
+  .slot-label {
+    font-family: var(--font-label);
+    font-size: 6px;
+    letter-spacing: 0.10em;
+    color: var(--bo-faint);
+  }
+
+  .slot-bar {
+    display: flex;
+    gap: 3px;
+  }
+
+  .slot-pip {
+    width: 8px;
+    height: 8px;
+    border-radius: 2px;
+    border: 1px solid var(--bo-border);
+    background: transparent;
+    transition: background 0.2s ease;
+  }
+
+  .slot-pip.filled {
+    background: var(--bo-violet);
+    border-color: var(--bo-violet);
+  }
+
+  .slot-count {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--bo-muted);
+  }
+
+  /* Loading / Error States */
+  .loading-state {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: var(--space-xl);
+    justify-content: center;
+  }
+
+  .loading-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--bo-violet);
+    animation: pulse 1s ease infinite;
+  }
+
+  @keyframes pulse {
+    0%, 100% { opacity: 0.3; }
+    50% { opacity: 1; }
+  }
+
+  .loading-text {
+    font-size: 12px;
+    color: var(--bo-faint);
+  }
+
+  .error-state {
+    text-align: center;
+    padding: var(--space-lg);
+  }
+
+  .error-text {
+    font-size: 12px;
+    color: var(--bo-rose);
+    margin: 0 0 var(--space-sm);
+  }
+
+  .retry-btn {
+    font-family: var(--font-label);
+    font-size: 7px;
+    letter-spacing: 0.10em;
+    color: var(--bo-violet);
+    background: none;
+    border: 1px solid var(--bo-violet);
+    padding: 4px 12px;
+    border-radius: 3px;
+    cursor: pointer;
+  }
+
+  .retry-btn:hover {
+    background: rgba(124, 58, 237, 0.1);
+  }
+
+  /* Equipped section */
+  .equipped-section {
+    min-height: 40px;
+  }
+
+  .equipped-list, .available-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  .equipped-card, .available-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-md);
+    padding: var(--space-sm) var(--space-md);
+    background: var(--bo-card);
+    border: 1px solid var(--bo-border);
+    border-radius: var(--radius-md);
+    transition: border-color 0.15s ease;
+  }
+
+  .equipped-card:hover, .available-card:hover {
+    border-color: var(--bo-bhi);
+  }
+
+  .skill-info {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    flex: 1;
+    min-width: 0;
+  }
+
+  .skill-cat-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .skill-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .skill-name {
+    font-family: var(--font-body);
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--bo-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .skill-desc {
+    font-size: 11px;
+    color: var(--bo-faint);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .skill-version {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--bo-faint);
+    flex-shrink: 0;
+  }
+
+  .skill-class-badge {
+    font-family: var(--font-label);
+    font-size: 6px;
+    letter-spacing: 0.10em;
+    color: var(--bo-faint);
+    border: 1px solid var(--bo-border);
+    padding: 1px 4px;
+    border-radius: 2px;
+    flex-shrink: 0;
+  }
+
+  .unequip-btn, .equip-btn {
+    font-family: var(--font-label);
+    font-size: 7px;
+    letter-spacing: 0.10em;
+    padding: 4px 10px;
+    border-radius: 3px;
+    cursor: pointer;
+    flex-shrink: 0;
+    border: 1px solid;
+    transition: all 0.15s ease;
+  }
+
+  .unequip-btn {
+    color: var(--bo-rose);
+    background: transparent;
+    border-color: rgba(244, 114, 182, 0.25);
+  }
+
+  .unequip-btn:hover:not(:disabled) {
+    background: rgba(244, 114, 182, 0.1);
+    border-color: var(--bo-rose);
+  }
+
+  .equip-btn {
+    color: var(--bo-teal);
+    background: transparent;
+    border-color: rgba(45, 212, 191, 0.25);
+  }
+
+  .equip-btn:hover:not(:disabled) {
+    background: rgba(45, 212, 191, 0.1);
+    border-color: var(--bo-teal);
+  }
+
+  .equip-btn:disabled, .unequip-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  /* Library toggle */
+  .library-toggle {
+    font-family: var(--font-label);
+    font-size: 7px;
+    letter-spacing: 0.10em;
+    color: var(--bo-violet);
+    background: none;
+    border: 1px solid var(--bo-border);
+    padding: 6px 14px;
+    border-radius: 4px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    align-self: flex-start;
+    transition: all 0.15s ease;
+  }
+
+  .library-toggle:hover {
+    border-color: var(--bo-violet);
+    background: rgba(124, 58, 237, 0.06);
+  }
+
+  .toggle-arrow {
+    display: inline-block;
+    width: 0;
+    height: 0;
+    border-left: 3px solid transparent;
+    border-right: 3px solid transparent;
+    border-top: 4px solid currentColor;
+    transition: transform 0.2s ease;
+  }
+
+  .toggle-arrow.open {
+    transform: rotate(180deg);
+  }
+
+  /* Library section */
+  .library-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+    padding: var(--space-md);
+    background: rgba(124, 58, 237, 0.03);
+    border: 1px solid var(--bo-border);
+    border-radius: var(--radius-md);
+  }
+
+  .filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .filter-chip {
+    font-family: var(--font-label);
+    font-size: 6px;
+    letter-spacing: 0.10em;
+    color: var(--bo-faint);
+    background: transparent;
+    border: 1px solid var(--bo-border);
+    padding: 3px 8px;
+    border-radius: 3px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+
+  .filter-chip:hover {
+    color: var(--bo-text);
+    border-color: var(--bo-bhi);
+  }
+
+  .filter-chip.active {
+    color: var(--bo-text);
+    background: rgba(124, 58, 237, 0.15);
+    border-color: var(--bo-violet);
+  }
+
+  .empty-msg {
+    font-size: 12px;
+    color: var(--bo-faint);
+    text-align: center;
+    padding: var(--space-lg);
+    margin: 0;
+  }
+</style>

--- a/services/ui/src/routes/(app)/evolution/[botId]/+page.server.ts
+++ b/services/ui/src/routes/(app)/evolution/[botId]/+page.server.ts
@@ -22,5 +22,7 @@ export const load: PageServerLoad = async ({ fetch, parent, params }) => {
   const profile = profileRes.status === 'fulfilled' && profileRes.value.ok
     ? await profileRes.value.json() : null;
 
-  return { botId, timeline, lineage, ledger, profile };
+  const userId = session.user?.id ?? '';
+
+  return { botId, timeline, lineage, ledger, profile, userId };
 };

--- a/services/ui/src/routes/(app)/evolution/[botId]/+page.svelte
+++ b/services/ui/src/routes/(app)/evolution/[botId]/+page.svelte
@@ -7,12 +7,13 @@
   import RuntimeStatus from '$lib/components/evolution/RuntimeStatus.svelte';
   import MutationDiff from '$lib/components/evolution/MutationDiff.svelte';
   import ExecutionLogs from '$lib/components/evolution/ExecutionLogs.svelte';
+  import SkillLoadout from '$lib/components/evolution/SkillLoadout.svelte';
   import type { PageData } from './$types';
   import type { MutationType } from '$lib/components/evolution/MutationDiff.svelte';
 
   let { data }: { data: PageData } = $props();
 
-  let activeTab = $state<'profile' | 'timeline' | 'lineage' | 'ledger' | 'logs'>('profile');
+  let activeTab = $state<'profile' | 'timeline' | 'lineage' | 'ledger' | 'logs' | 'skills'>('profile');
   let diffState = $state<{
     childId: string;
     parentId: string;
@@ -21,6 +22,7 @@
 
   const TABS = [
     { id: 'profile' as const, label: 'PROFILE' },
+    { id: 'skills' as const, label: 'SKILLS' },
     { id: 'timeline' as const, label: 'TIMELINE' },
     { id: 'lineage' as const, label: 'LINEAGE' },
     { id: 'ledger' as const, label: 'LEDGER' },
@@ -154,6 +156,12 @@
       {/if}
     {:else if activeTab === 'ledger'}
       <ExperimentLedger rows={data.ledger} ondiff={handleLedgerDiffRequest} />
+    {:else if activeTab === 'skills'}
+      <SkillLoadout
+        botId={data.botId}
+        userId={data.userId}
+        agentClass={data.profile?.currentClass ?? null}
+      />
     {:else if activeTab === 'logs'}
       <ExecutionLogs botId={data.botId} />
     {/if}

--- a/services/ui/src/routes/(app)/skills/+page.server.ts
+++ b/services/ui/src/routes/(app)/skills/+page.server.ts
@@ -1,0 +1,15 @@
+import type { PageServerLoad } from './$types';
+import { error } from '@sveltejs/kit';
+
+export const load: PageServerLoad = async ({ fetch, parent }) => {
+  const { session } = await parent();
+  if (!session) throw error(401, 'Not authenticated');
+
+  const userId = session.user?.id;
+  if (!userId) throw error(401, 'No user ID in session');
+
+  const skillsRes = await fetch(`/api/akasa/skills?userId=${encodeURIComponent(userId)}`);
+  const skills = skillsRes.ok ? await skillsRes.json() : [];
+
+  return { skills, userId };
+};

--- a/services/ui/src/routes/(app)/skills/+page.svelte
+++ b/services/ui/src/routes/(app)/skills/+page.svelte
@@ -1,0 +1,866 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { setMode, getMode, type AkasaMode } from '$lib/mode';
+  import { getSkills, createSkill, updateSkill, deleteSkill, type Skill } from '$lib/api';
+  import SkillEffectiveness from '$lib/components/evolution/SkillEffectiveness.svelte';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  let previousMode: AkasaMode | null = $state(null);
+
+  onMount(() => {
+    previousMode = getMode();
+    setMode('back-office');
+    return () => {
+      if (previousMode && previousMode !== 'back-office') {
+        setMode(previousMode);
+      }
+    };
+  });
+
+  const CATEGORIES = [
+    'communication', 'analysis', 'creation', 'automation',
+    'research', 'coordination', 'monitoring', 'other',
+  ] as const;
+
+  const CATEGORY_COLORS: Record<string, string> = {
+    communication: 'var(--bo-teal)',
+    analysis: 'var(--bo-violet)',
+    creation: 'var(--bo-amber)',
+    automation: 'var(--bo-rose)',
+    research: 'var(--bo-vb)',
+    coordination: 'var(--bo-teal)',
+    monitoring: 'var(--bo-amber)',
+    other: 'var(--bo-faint)',
+  };
+
+  let skills = $state<Skill[]>(data.skills);
+  let filterCategory = $state<string>('');
+  let showCreate = $state(false);
+  let editingSkill = $state<Skill | null>(null);
+  let expandedSkillId = $state<string | null>(null);
+  let loading = $state(false);
+  let actionError = $state<string | null>(null);
+
+  // Create form state
+  let formContent = $state('');
+  let formErrors = $state<string[]>([]);
+
+  const filteredSkills = $derived.by(() => {
+    if (!filterCategory) return skills;
+    return skills.filter((s) => s.category === filterCategory);
+  });
+
+  const categoryStats = $derived.by(() => {
+    const counts: Record<string, number> = {};
+    for (const s of skills) {
+      counts[s.category] = (counts[s.category] ?? 0) + 1;
+    }
+    return counts;
+  });
+
+  const SKILL_TEMPLATE = `---
+name: "My Skill"
+description: "What this skill does"
+category: other
+version: "1.0.0"
+triggers: ["pattern.*match"]
+requires_tools: []
+requires_skills: []
+min_agent_class: "Novice"
+---
+
+## Purpose
+
+Describe what this skill enables the agent to do.
+
+## Procedure
+
+Step-by-step instructions for the agent.
+
+1. First step
+2. Second step
+3. Third step
+
+## Reference
+
+- Key concepts or links the agent should know about.`;
+
+  async function handleCreate() {
+    if (!formContent.trim()) {
+      formErrors = ['Content is required'];
+      return;
+    }
+
+    loading = true;
+    actionError = null;
+    formErrors = [];
+
+    try {
+      const created = await createSkill({
+        userId: data.userId,
+        content: formContent,
+        source: 'user_created',
+      });
+      skills = [created, ...skills];
+      formContent = '';
+      showCreate = false;
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (msg.includes('errors')) {
+        try {
+          const parsed = JSON.parse(msg.split(': ').slice(1).join(': '));
+          formErrors = parsed.errors ?? [msg];
+        } catch {
+          formErrors = [msg];
+        }
+      } else {
+        actionError = msg;
+      }
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function handleUpdate() {
+    if (!editingSkill) return;
+
+    loading = true;
+    actionError = null;
+    formErrors = [];
+
+    try {
+      const updated = await updateSkill(editingSkill.id, {
+        content: formContent,
+      });
+      skills = skills.map((s) => (s.id === updated.id ? updated : s));
+      editingSkill = null;
+      formContent = '';
+    } catch (err) {
+      const msg = (err as Error).message;
+      formErrors = [msg];
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function handleDelete(skillId: string) {
+    loading = true;
+    actionError = null;
+
+    try {
+      await deleteSkill(skillId);
+      skills = skills.filter((s) => s.id !== skillId);
+      if (expandedSkillId === skillId) expandedSkillId = null;
+    } catch (err) {
+      actionError = (err as Error).message;
+    } finally {
+      loading = false;
+    }
+  }
+
+  function startEdit(skill: Skill) {
+    editingSkill = skill;
+    formContent = skill.content;
+    showCreate = false;
+  }
+
+  function startCreate() {
+    showCreate = true;
+    editingSkill = null;
+    formContent = SKILL_TEMPLATE;
+    formErrors = [];
+  }
+
+  function cancelForm() {
+    showCreate = false;
+    editingSkill = null;
+    formContent = '';
+    formErrors = [];
+  }
+
+  function toggleExpand(skillId: string) {
+    expandedSkillId = expandedSkillId === skillId ? null : skillId;
+  }
+
+  async function refreshSkills() {
+    try {
+      skills = await getSkills(data.userId, filterCategory ? { category: filterCategory } : undefined);
+    } catch { /* silent */ }
+  }
+</script>
+
+<div class="skills-page">
+  <div class="page-header">
+    <div class="header-left">
+      <h1 class="page-title">Skills Library</h1>
+      <span class="skill-count">{skills.length} skill{skills.length !== 1 ? 's' : ''}</span>
+    </div>
+    <button class="create-btn" onclick={startCreate} disabled={showCreate || editingSkill !== null}>
+      + NEW SKILL
+    </button>
+  </div>
+
+  <!-- Category filter bar -->
+  <div class="filter-bar">
+    <button
+      class="filter-chip"
+      class:active={filterCategory === ''}
+      onclick={() => (filterCategory = '')}
+    >
+      ALL
+      <span class="chip-count">{skills.length}</span>
+    </button>
+    {#each CATEGORIES as cat}
+      {#if categoryStats[cat]}
+        <button
+          class="filter-chip"
+          class:active={filterCategory === cat}
+          onclick={() => (filterCategory = cat)}
+        >
+          <span class="chip-dot" style="background: {CATEGORY_COLORS[cat]}"></span>
+          {cat.toUpperCase()}
+          <span class="chip-count">{categoryStats[cat]}</span>
+        </button>
+      {/if}
+    {/each}
+  </div>
+
+  {#if actionError}
+    <div class="action-error">
+      <span>{actionError}</span>
+      <button class="dismiss-btn" onclick={() => (actionError = null)}>dismiss</button>
+    </div>
+  {/if}
+
+  <!-- Create / Edit form -->
+  {#if showCreate || editingSkill}
+    <div class="form-section">
+      <div class="form-header">
+        <h2 class="form-title">{editingSkill ? 'Edit Skill' : 'Create New Skill'}</h2>
+        <button class="cancel-btn" onclick={cancelForm}>CANCEL</button>
+      </div>
+
+      {#if formErrors.length > 0}
+        <div class="form-errors">
+          {#each formErrors as err}
+            <p class="form-error">{err}</p>
+          {/each}
+        </div>
+      {/if}
+
+      <textarea
+        class="content-editor"
+        bind:value={formContent}
+        rows="20"
+        placeholder="Paste your SKILL.md content here..."
+        spellcheck="false"
+      ></textarea>
+
+      <div class="form-actions">
+        <button
+          class="submit-btn"
+          disabled={loading}
+          onclick={editingSkill ? handleUpdate : handleCreate}
+        >
+          {loading ? 'SAVING...' : editingSkill ? 'UPDATE SKILL' : 'CREATE SKILL'}
+        </button>
+      </div>
+    </div>
+  {/if}
+
+  <!-- Skills list -->
+  {#if filteredSkills.length === 0 && !showCreate}
+    <div class="empty-state">
+      <p class="empty-title">
+        {skills.length === 0 ? 'No skills yet' : 'No skills in this category'}
+      </p>
+      <p class="empty-body">
+        {skills.length === 0
+          ? 'Create your first skill to start building your agent capabilities.'
+          : 'Try a different filter or create a new skill.'}
+      </p>
+      {#if skills.length === 0}
+        <button class="create-btn small" onclick={startCreate}>+ CREATE SKILL</button>
+      {/if}
+    </div>
+  {:else}
+    <div class="skills-list">
+      {#each filteredSkills as skill (skill.id)}
+        <div class="skill-card" class:expanded={expandedSkillId === skill.id}>
+          <button class="skill-card-header" onclick={() => toggleExpand(skill.id)}>
+            <div class="skill-card-left">
+              <span
+                class="cat-dot"
+                style="background: {CATEGORY_COLORS[skill.category] ?? 'var(--bo-faint)'}"
+              ></span>
+              <div class="skill-title-block">
+                <span class="skill-name">{skill.name}</span>
+                <span class="skill-desc">{skill.description}</span>
+              </div>
+            </div>
+            <div class="skill-card-right">
+              <span class="skill-category-label">{skill.category.toUpperCase()}</span>
+              <span class="skill-version">v{skill.version}</span>
+              <span class="skill-class">{skill.minAgentClass}</span>
+              <span class="expand-icon" class:open={expandedSkillId === skill.id}></span>
+            </div>
+          </button>
+
+          {#if expandedSkillId === skill.id}
+            <div class="skill-detail">
+              <!-- Effectiveness Stats -->
+              <div class="detail-section">
+                <h4 class="detail-label">EFFECTIVENESS</h4>
+                <SkillEffectiveness stats={skill.effectivenessStats} />
+              </div>
+
+              <!-- Triggers -->
+              {#if skill.triggers && skill.triggers.length > 0}
+                <div class="detail-section">
+                  <h4 class="detail-label">TRIGGERS</h4>
+                  <div class="tag-list">
+                    {#each skill.triggers as trigger}
+                      <span class="tag">{trigger}</span>
+                    {/each}
+                  </div>
+                </div>
+              {/if}
+
+              <!-- Required Tools -->
+              {#if skill.requiresTools && skill.requiresTools.length > 0}
+                <div class="detail-section">
+                  <h4 class="detail-label">REQUIRED TOOLS</h4>
+                  <div class="tag-list">
+                    {#each skill.requiresTools as tool}
+                      <span class="tag tool">{tool}</span>
+                    {/each}
+                  </div>
+                </div>
+              {/if}
+
+              <!-- Source badge -->
+              <div class="detail-section inline">
+                <span class="source-badge">{skill.source.replace('_', ' ').toUpperCase()}</span>
+                <span class="created-at">
+                  Created {new Date(skill.createdAt).toLocaleDateString()}
+                </span>
+              </div>
+
+              <!-- Actions -->
+              <div class="skill-actions">
+                <button class="action-btn edit" onclick={() => startEdit(skill)}>
+                  EDIT
+                </button>
+                <button
+                  class="action-btn delete"
+                  disabled={loading}
+                  onclick={() => handleDelete(skill.id)}
+                >
+                  DELETE
+                </button>
+              </div>
+            </div>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .skills-page {
+    max-width: 900px;
+    padding: var(--space-2xl) var(--space-xl) var(--space-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+  }
+
+  .page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .header-left {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-md);
+  }
+
+  .page-title {
+    font-family: var(--font-display);
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--bo-text);
+    margin: 0;
+  }
+
+  .skill-count {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--bo-faint);
+  }
+
+  .create-btn {
+    font-family: var(--font-label);
+    font-size: 7px;
+    letter-spacing: 0.10em;
+    color: var(--bo-bg);
+    background: var(--bo-violet);
+    border: none;
+    padding: 6px 14px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: opacity 0.15s ease;
+  }
+
+  .create-btn:hover:not(:disabled) {
+    opacity: 0.85;
+  }
+
+  .create-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .create-btn.small {
+    margin-top: var(--space-md);
+  }
+
+  /* Filter bar */
+  .filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .filter-chip {
+    font-family: var(--font-label);
+    font-size: 6px;
+    letter-spacing: 0.10em;
+    color: var(--bo-faint);
+    background: transparent;
+    border: 1px solid var(--bo-border);
+    padding: 4px 10px;
+    border-radius: 3px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    transition: all 0.15s ease;
+  }
+
+  .filter-chip:hover {
+    color: var(--bo-text);
+    border-color: var(--bo-bhi);
+  }
+
+  .filter-chip.active {
+    color: var(--bo-text);
+    background: rgba(124, 58, 237, 0.15);
+    border-color: var(--bo-violet);
+  }
+
+  .chip-dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+  }
+
+  .chip-count {
+    font-family: var(--font-mono);
+    font-size: 8px;
+    opacity: 0.6;
+  }
+
+  /* Error banner */
+  .action-error {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-sm) var(--space-md);
+    background: rgba(244, 114, 182, 0.08);
+    border: 1px solid rgba(244, 114, 182, 0.25);
+    border-radius: var(--radius-md);
+    font-size: 12px;
+    color: var(--bo-rose);
+  }
+
+  .dismiss-btn {
+    font-family: var(--font-label);
+    font-size: 6px;
+    letter-spacing: 0.10em;
+    color: var(--bo-rose);
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  /* Form section */
+  .form-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+    padding: var(--space-lg);
+    background: var(--bo-card);
+    border: 1px solid var(--bo-border);
+    border-radius: var(--radius-md);
+  }
+
+  .form-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .form-title {
+    font-family: var(--font-display);
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--bo-text);
+    margin: 0;
+  }
+
+  .cancel-btn {
+    font-family: var(--font-label);
+    font-size: 7px;
+    letter-spacing: 0.10em;
+    color: var(--bo-faint);
+    background: none;
+    border: 1px solid var(--bo-border);
+    padding: 4px 10px;
+    border-radius: 3px;
+    cursor: pointer;
+  }
+
+  .cancel-btn:hover {
+    color: var(--bo-text);
+    border-color: var(--bo-bhi);
+  }
+
+  .form-errors {
+    padding: var(--space-sm) var(--space-md);
+    background: rgba(244, 114, 182, 0.06);
+    border: 1px solid rgba(244, 114, 182, 0.2);
+    border-radius: var(--radius-md);
+  }
+
+  .form-error {
+    font-size: 11px;
+    color: var(--bo-rose);
+    margin: 2px 0;
+  }
+
+  .content-editor {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--bo-text);
+    background: var(--bo-bg);
+    border: 1px solid var(--bo-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-md);
+    resize: vertical;
+    min-height: 300px;
+  }
+
+  .content-editor::placeholder {
+    color: var(--bo-faint);
+  }
+
+  .content-editor:focus {
+    outline: none;
+    border-color: var(--bo-violet);
+  }
+
+  .form-actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .submit-btn {
+    font-family: var(--font-label);
+    font-size: 7px;
+    letter-spacing: 0.10em;
+    color: var(--bo-bg);
+    background: var(--bo-violet);
+    border: none;
+    padding: 6px 18px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: opacity 0.15s ease;
+  }
+
+  .submit-btn:hover:not(:disabled) {
+    opacity: 0.85;
+  }
+
+  .submit-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* Empty state */
+  .empty-state {
+    padding: var(--space-2xl);
+    background: var(--bo-card);
+    border: 1px solid var(--bo-border);
+    border-radius: var(--radius-md);
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .empty-title {
+    font-family: var(--font-display);
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--bo-text);
+    margin: 0 0 var(--space-sm);
+  }
+
+  .empty-body {
+    font-size: 13px;
+    color: var(--bo-faint);
+    margin: 0;
+  }
+
+  /* Skills list */
+  .skills-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  .skill-card {
+    background: var(--bo-card);
+    border: 1px solid var(--bo-border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    transition: border-color 0.15s ease;
+  }
+
+  .skill-card:hover {
+    border-color: var(--bo-bhi);
+  }
+
+  .skill-card.expanded {
+    border-color: var(--bo-violet);
+  }
+
+  .skill-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-md);
+    padding: var(--space-md);
+    width: 100%;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    color: inherit;
+  }
+
+  .skill-card-left {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    flex: 1;
+    min-width: 0;
+  }
+
+  .cat-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .skill-title-block {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .skill-name {
+    font-family: var(--font-body);
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--bo-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .skill-desc {
+    font-size: 11px;
+    color: var(--bo-faint);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .skill-card-right {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    flex-shrink: 0;
+  }
+
+  .skill-category-label {
+    font-family: var(--font-label);
+    font-size: 6px;
+    letter-spacing: 0.10em;
+    color: var(--bo-faint);
+  }
+
+  .skill-version {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--bo-faint);
+  }
+
+  .skill-class {
+    font-family: var(--font-label);
+    font-size: 6px;
+    letter-spacing: 0.10em;
+    color: var(--bo-faint);
+    border: 1px solid var(--bo-border);
+    padding: 1px 4px;
+    border-radius: 2px;
+  }
+
+  .expand-icon {
+    display: inline-block;
+    width: 0;
+    height: 0;
+    border-left: 3px solid transparent;
+    border-right: 3px solid transparent;
+    border-top: 4px solid var(--bo-faint);
+    transition: transform 0.2s ease;
+  }
+
+  .expand-icon.open {
+    transform: rotate(180deg);
+  }
+
+  /* Skill detail */
+  .skill-detail {
+    padding: 0 var(--space-md) var(--space-md);
+    border-top: 1px solid var(--bo-border);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+    padding-top: var(--space-md);
+  }
+
+  .detail-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  .detail-section.inline {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-md);
+  }
+
+  .detail-label {
+    font-family: var(--font-label);
+    font-size: 6px;
+    letter-spacing: 0.10em;
+    color: var(--bo-faint);
+    margin: 0;
+  }
+
+  .tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .tag {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--bo-muted);
+    background: rgba(124, 58, 237, 0.06);
+    border: 1px solid var(--bo-border);
+    padding: 2px 6px;
+    border-radius: 2px;
+  }
+
+  .tag.tool {
+    color: var(--bo-amber);
+    background: rgba(251, 191, 36, 0.06);
+    border-color: rgba(251, 191, 36, 0.2);
+  }
+
+  .source-badge {
+    font-family: var(--font-label);
+    font-size: 6px;
+    letter-spacing: 0.10em;
+    color: var(--bo-muted);
+    background: rgba(236, 232, 255, 0.04);
+    border: 1px solid var(--bo-border);
+    padding: 2px 6px;
+    border-radius: 2px;
+  }
+
+  .created-at {
+    font-size: 11px;
+    color: var(--bo-faint);
+  }
+
+  .skill-actions {
+    display: flex;
+    gap: var(--space-sm);
+    padding-top: var(--space-sm);
+    border-top: 1px solid var(--bo-border);
+  }
+
+  .action-btn {
+    font-family: var(--font-label);
+    font-size: 7px;
+    letter-spacing: 0.10em;
+    padding: 4px 12px;
+    border-radius: 3px;
+    cursor: pointer;
+    border: 1px solid;
+    background: transparent;
+    transition: all 0.15s ease;
+  }
+
+  .action-btn.edit {
+    color: var(--bo-violet);
+    border-color: rgba(124, 58, 237, 0.25);
+  }
+
+  .action-btn.edit:hover {
+    background: rgba(124, 58, 237, 0.1);
+    border-color: var(--bo-violet);
+  }
+
+  .action-btn.delete {
+    color: var(--bo-rose);
+    border-color: rgba(244, 114, 182, 0.25);
+  }
+
+  .action-btn.delete:hover:not(:disabled) {
+    background: rgba(244, 114, 182, 0.1);
+    border-color: var(--bo-rose);
+  }
+
+  .action-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+</style>


### PR DESCRIPTION
## Summary

- **Skills Library page** at `/skills` — browse, create, edit, and delete user skills with category filtering, SKILL.md content editor, and expandable detail cards showing triggers, required tools, and source
- **Skill Loadout editor** tab on agent detail page (`/evolution/[botId]`) — equip/unequip skills with visual slot meter showing capacity by agent class (Novice: 3, Understudy: 5, Artisan: 8), inline skill library browser with category filtering
- **Effectiveness display** component showing activation count, success rate bar, average duration, and last-used timestamp from `effectivenessStats` JSONB column
- **API client functions** in `lib/api.ts` for all skill CRUD and agent loadout endpoints (`getSkills`, `createSkill`, `updateSkill`, `deleteSkill`, `getAgentSkills`, `equipSkill`, `unequipSkill`)
- **SKILLS nav link** added to global navbar between TOOLS and EVOLUTION

Closes #80

## Test plan

- [ ] Navigate to `/skills` — verify page loads with Director's Cut dark theme
- [ ] Create a new skill using the SKILL.md template — verify validation errors display for missing fields
- [ ] Edit an existing skill — verify content updates persist
- [ ] Delete a skill — verify it's removed from the list
- [ ] Filter by category — verify filter chips work correctly
- [ ] Navigate to `/evolution/[botId]` — verify SKILLS tab appears
- [ ] Equip a skill from the loadout library — verify slot meter updates
- [ ] Unequip a skill — verify it returns to the available pool
- [ ] Verify capacity limits enforce correctly (cannot equip beyond class limit)
- [ ] Expand a skill card — verify effectiveness stats render (or "No activation data yet")

🤖 Generated with [Claude Code](https://claude.com/claude-code)