### PR TITLE
feat(tools): OpenAPI/Swagger import for custom tool registration

### DIFF
--- a/packages/db/migrations/0020_tool_registry.sql
+++ b/packages/db/migrations/0020_tool_registry.sql
@@ -1,0 +1,29 @@
+-- Migration: 0020_tool_registry
+-- Creates the tool_registry table for OpenAPI/Swagger imported tool endpoints.
+-- Each row represents a single operation from an imported spec.
+
+CREATE TABLE IF NOT EXISTS "tool_registry" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" text NOT NULL,
+  "spec_id" uuid NOT NULL,
+  "spec_title" text NOT NULL,
+  "spec_version" text,
+  "spec_url" text,
+  "base_url" text NOT NULL,
+  "operation_id" text,
+  "method" text NOT NULL,
+  "path" text NOT NULL,
+  "summary" text,
+  "description" text,
+  "parameters" jsonb,
+  "request_body" jsonb,
+  "response_schema" jsonb,
+  "tags" jsonb DEFAULT '[]'::jsonb,
+  "is_enabled" boolean NOT NULL DEFAULT true,
+  "created_at" timestamp(3) with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp(3) with time zone NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "tool_registry_user_id_idx" ON "tool_registry" ("user_id");
+CREATE INDEX IF NOT EXISTS "tool_registry_spec_id_idx" ON "tool_registry" ("spec_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "tool_registry_spec_method_path_uniq" ON "tool_registry" ("spec_id", "method", "path");

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -120,6 +120,27 @@
       "when": 1773100000000,
       "tag": "0017_add_akashic_publish",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1773200000000,
+      "tag": "0018_evolution_campaigns",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1773300000000,
+      "tag": "0019_learned_skills",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1773400000000,
+      "tag": "0020_tool_registry",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -24,3 +24,4 @@ export * from "./evolution-campaigns";
 export * from "./user-preferences";
 export * from "./api-keys";
 export * from "./learned-skills";
+export * from "./tool-registry";

--- a/packages/db/src/schema/tool-registry.ts
+++ b/packages/db/src/schema/tool-registry.ts
@@ -1,0 +1,53 @@
+import { pgTable, uuid, text, timestamp, jsonb, boolean, index, uniqueIndex } from 'drizzle-orm/pg-core';
+
+/**
+ * tool_registry — stores tool endpoint definitions imported from OpenAPI/Swagger specs.
+ *
+ * Each row represents a single operation (e.g., GET /contacts, POST /deals)
+ * from an imported OpenAPI spec. The spec-level metadata (title, version, baseUrl)
+ * is denormalized onto each row via specId grouping.
+ *
+ * Uses logical FK on userId (no references()) — same pattern as tool_connections.
+ */
+export const toolRegistry = pgTable(
+  'tool_registry',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: text('user_id').notNull(),
+
+    // Spec-level metadata (shared across all endpoints from the same import)
+    specId: uuid('spec_id').notNull(), // groups endpoints from the same import
+    specTitle: text('spec_title').notNull(),
+    specVersion: text('spec_version'),
+    specUrl: text('spec_url'), // original URL or null if raw spec was pasted
+    baseUrl: text('base_url').notNull(), // resolved server URL for invocations
+
+    // Endpoint-level metadata
+    operationId: text('operation_id'),
+    method: text('method').notNull(), // 'get' | 'post' | 'put' | 'patch' | 'delete'
+    path: text('path').notNull(), // e.g. '/contacts/{contactId}'
+    summary: text('summary'),
+    description: text('description'),
+
+    // Schema data for tool invocation
+    parameters: jsonb('parameters').$type<Record<string, unknown>[]>(), // query, path, header params
+    requestBody: jsonb('request_body').$type<Record<string, unknown>>(), // dereferenced request body schema
+    responseSchema: jsonb('response_schema').$type<Record<string, unknown>>(), // dereferenced 200 response schema
+    tags: jsonb('tags').$type<string[]>().default([]),
+
+    // Status
+    isEnabled: boolean('is_enabled').notNull().default(true),
+
+    // Tracking
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index('tool_registry_user_id_idx').on(t.userId),
+    index('tool_registry_spec_id_idx').on(t.specId),
+    uniqueIndex('tool_registry_spec_method_path_uniq').on(t.specId, t.method, t.path),
+  ],
+);
+
+export type ToolRegistryEntry = typeof toolRegistry.$inferSelect;
+export type NewToolRegistryEntry = typeof toolRegistry.$inferInsert;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -699,6 +699,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.29
         version: 3.0.29(zod@4.3.6)
+      '@apidevtools/swagger-parser':
+        specifier: ^12.1.0
+        version: 12.1.0(openapi-types@12.1.3)
       '@claw/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -1046,6 +1049,22 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@apidevtools/json-schema-ref-parser@14.0.1':
+    resolution: {integrity: sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==}
+    engines: {node: '>= 16'}
+
+  '@apidevtools/openapi-schemas@2.1.0':
+    resolution: {integrity: sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==}
+    engines: {node: '>=10'}
+
+  '@apidevtools/swagger-methods@3.0.2':
+    resolution: {integrity: sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==}
+
+  '@apidevtools/swagger-parser@12.1.0':
+    resolution: {integrity: sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==}
+    peerDependencies:
+      openapi-types: '>=7'
 
   '@asamuzakjp/css-color@5.0.1':
     resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
@@ -2538,6 +2557,9 @@ packages:
   '@types/jsdom@28.0.1':
     resolution: {integrity: sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
 
@@ -2710,6 +2732,14 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -2739,6 +2769,9 @@ packages:
 
   append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2917,6 +2950,9 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  call-me-maybe@1.0.2:
+    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -3755,6 +3791,10 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
   jsdom@28.1.0:
     resolution: {integrity: sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -4003,6 +4043,9 @@ packages:
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
+
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
   p-defer@3.0.0:
     resolution: {integrity: sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==}
@@ -4883,6 +4926,25 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 3.25.76
+
+  '@apidevtools/json-schema-ref-parser@14.0.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.1.1
+
+  '@apidevtools/openapi-schemas@2.1.0': {}
+
+  '@apidevtools/swagger-methods@3.0.2': {}
+
+  '@apidevtools/swagger-parser@12.1.0(openapi-types@12.1.3)':
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 14.0.1
+      '@apidevtools/openapi-schemas': 2.1.0
+      '@apidevtools/swagger-methods': 3.0.2
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      call-me-maybe: 1.0.2
+      openapi-types: 12.1.3
 
   '@asamuzakjp/css-color@5.0.1':
     dependencies:
@@ -6585,6 +6647,8 @@ snapshots:
       parse5: 7.3.0
       undici-types: 7.24.5
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/long@4.0.2': {}
 
   '@types/methods@1.1.4': {}
@@ -6817,6 +6881,10 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
 
+  ajv-draft-04@1.0.0(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -6839,6 +6907,8 @@ snapshots:
   ansi-styles@6.2.3: {}
 
   append-field@1.0.0: {}
+
+  argparse@2.0.1: {}
 
   aria-query@5.3.2: {}
 
@@ -7006,6 +7076,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  call-me-maybe@1.0.2: {}
 
   chai@5.3.3:
     dependencies:
@@ -7870,6 +7942,10 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
   jsdom@28.1.0(@noble/hashes@2.0.1):
     dependencies:
       '@acemir/cssom': 0.9.31
@@ -8095,6 +8171,8 @@ snapshots:
       is-inside-container: 1.0.0
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
+
+  openapi-types@12.1.3: {}
 
   p-defer@3.0.0: {}
 

--- a/services/akasa-server/package.json
+++ b/services/akasa-server/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.45",
     "@ai-sdk/openai": "^3.0.29",
+    "@apidevtools/swagger-parser": "^12.1.0",
     "@claw/db": "workspace:*",
     "@claw/shared-types": "workspace:*",
     "@paperclipai/db": "workspace:*",

--- a/services/akasa-server/src/routes/index.ts
+++ b/services/akasa-server/src/routes/index.ts
@@ -16,6 +16,7 @@ import { commandsRouter } from './commands.js';
 import { settingsRouter } from './settings.js';
 import { skillsRouter } from './skills.js';
 import { agentSkillsRouter } from './agent-skills.js';
+import { toolRegistryRouter } from './tool-registry.js';
 
 const akasaRouter = Router();
 
@@ -72,5 +73,8 @@ akasaRouter.use('/akasa/skills', skillsRouter());
 
 // Agent skill loadout routes (equip/unequip/list)
 akasaRouter.use('/akasa/agents', agentSkillsRouter());
+
+// OpenAPI/Swagger import and tool registry management
+akasaRouter.use('/akasa/tool-registry', toolRegistryRouter());
 
 export { akasaRouter };

--- a/services/akasa-server/src/routes/tool-registry.ts
+++ b/services/akasa-server/src/routes/tool-registry.ts
@@ -1,0 +1,125 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import {
+  parseOpenApiSpec,
+  importEndpoints,
+  listToolRegistry,
+  deleteSpec,
+  toggleEndpoint,
+} from '../services/openapi-import.js';
+
+/**
+ * Express router factory for OpenAPI/Swagger tool import and registry management.
+ * Mount at /akasa/tool-registry.
+ */
+export function toolRegistryRouter(): Router {
+  const router = Router();
+
+  // ── POST /preview — parse spec and return discovered endpoints (no persistence) ──
+  router.post('/preview', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { specUrl, specJson } = req.body as {
+        specUrl?: string;
+        specJson?: Record<string, unknown>;
+      };
+
+      if (!specUrl && !specJson) {
+        res.status(400).json({ error: 'Provide either specUrl or specJson' });
+        return;
+      }
+
+      const input = specUrl ?? specJson!;
+      const parsed = await parseOpenApiSpec(input);
+      res.json(parsed);
+    } catch (err) {
+      res.status(422).json({ error: `Failed to parse OpenAPI spec: ${(err as Error).message}` });
+    }
+  });
+
+  // ── POST /import — import selected endpoints from a spec ─────────────────────
+  router.post('/import', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { userId, specUrl, specJson, selectedEndpoints } = req.body as {
+        userId: string;
+        specUrl?: string;
+        specJson?: Record<string, unknown>;
+        selectedEndpoints?: Array<{ method: string; path: string }>;
+      };
+
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      if (!specUrl && !specJson) {
+        res.status(400).json({ error: 'Provide either specUrl or specJson' });
+        return;
+      }
+
+      const input = specUrl ?? specJson!;
+      const parsed = await parseOpenApiSpec(input);
+      const imported = await importEndpoints(userId, parsed, specUrl ?? null, selectedEndpoints);
+      res.status(201).json(imported);
+    } catch (err) {
+      res.status(422).json({ error: `Import failed: ${(err as Error).message}` });
+    }
+  });
+
+  // ── GET / — list all imported tool endpoints for a user ──────────────────────
+  router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.query['userId'] as string | undefined;
+      if (!userId) {
+        res.status(400).json({ error: 'userId query parameter is required' });
+        return;
+      }
+
+      const entries = await listToolRegistry(userId);
+      res.json(entries);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // ── DELETE /:specId — remove all endpoints from a specific import ────────────
+  router.delete('/:specId', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { specId } = req.params;
+      const userId = req.query['userId'] as string | undefined;
+
+      if (!specId || !userId) {
+        res.status(400).json({ error: 'specId param and userId query parameter are required' });
+        return;
+      }
+
+      const count = await deleteSpec(userId, specId as string);
+      res.json({ deleted: count });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // ── PATCH /:id/toggle — enable or disable a specific endpoint ────────────────
+  router.patch('/:id/toggle', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = req.params;
+      const { userId, isEnabled } = req.body as { userId: string; isEnabled: boolean };
+
+      if (!id || !userId || isEnabled === undefined) {
+        res.status(400).json({ error: 'id param, userId, and isEnabled are required' });
+        return;
+      }
+
+      const updated = await toggleEndpoint(userId, id as string, isEnabled);
+      if (!updated) {
+        res.status(404).json({ error: 'Registry entry not found' });
+        return;
+      }
+
+      res.json(updated);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/services/akasa-server/src/services/openapi-import.ts
+++ b/services/akasa-server/src/services/openapi-import.ts
@@ -1,0 +1,226 @@
+import crypto from 'node:crypto';
+import SwaggerParser from '@apidevtools/swagger-parser';
+import { db, toolRegistry } from '@claw/db';
+import { eq, and } from 'drizzle-orm';
+import type { NewToolRegistryEntry, ToolRegistryEntry } from '@claw/db';
+
+/**
+ * Represents a discovered endpoint from an OpenAPI spec, before DB insertion.
+ */
+export interface DiscoveredEndpoint {
+  operationId: string | null;
+  method: string;
+  path: string;
+  summary: string | null;
+  description: string | null;
+  parameters: Record<string, unknown>[] | null;
+  requestBody: Record<string, unknown> | null;
+  responseSchema: Record<string, unknown> | null;
+  tags: string[];
+}
+
+/**
+ * Parsed OpenAPI spec metadata + discovered endpoints.
+ */
+export interface ParsedSpec {
+  title: string;
+  version: string | null;
+  baseUrl: string;
+  endpoints: DiscoveredEndpoint[];
+}
+
+const SUPPORTED_METHODS = ['get', 'post', 'put', 'patch', 'delete'] as const;
+
+/**
+ * Parse and dereference an OpenAPI/Swagger spec from a URL or raw JSON object.
+ * Uses SwaggerParser.dereference() to resolve all $ref pointers.
+ */
+export async function parseOpenApiSpec(input: string | Record<string, unknown>): Promise<ParsedSpec> {
+  // dereference resolves all $ref pointers in-place
+  const api = await SwaggerParser.dereference(input as string);
+
+  const info = api.info;
+  if (!info?.title) {
+    throw new Error('OpenAPI spec missing required info.title');
+  }
+
+  // Resolve base URL from servers array (OpenAPI 3.x) or host+basePath (Swagger 2.x)
+  let baseUrl = '';
+  const apiAny = api as Record<string, unknown>;
+  if (Array.isArray(apiAny['servers']) && apiAny['servers'].length > 0) {
+    const server = apiAny['servers'][0] as Record<string, unknown>;
+    baseUrl = (server['url'] as string) ?? '';
+  } else if (apiAny['host']) {
+    const scheme = Array.isArray(apiAny['schemes']) && apiAny['schemes'].length > 0
+      ? (apiAny['schemes'][0] as string)
+      : 'https';
+    const basePath = (apiAny['basePath'] as string) ?? '';
+    baseUrl = `${scheme}://${apiAny['host'] as string}${basePath}`;
+  }
+
+  if (!baseUrl) {
+    throw new Error('Could not resolve base URL from OpenAPI spec (no servers or host field)');
+  }
+
+  // Strip trailing slash
+  baseUrl = baseUrl.replace(/\/$/, '');
+
+  const endpoints: DiscoveredEndpoint[] = [];
+
+  const paths = api.paths ?? {};
+  for (const [pathStr, pathItem] of Object.entries(paths)) {
+    if (!pathItem || typeof pathItem !== 'object') continue;
+
+    for (const method of SUPPORTED_METHODS) {
+      const operation = (pathItem as Record<string, unknown>)[method];
+      if (!operation || typeof operation !== 'object') continue;
+
+      const op = operation as Record<string, unknown>;
+
+      // Extract parameters (path-level + operation-level merged)
+      const pathLevelParams = Array.isArray((pathItem as Record<string, unknown>)['parameters'])
+        ? ((pathItem as Record<string, unknown>)['parameters'] as Record<string, unknown>[])
+        : [];
+      const opLevelParams = Array.isArray(op['parameters'])
+        ? (op['parameters'] as Record<string, unknown>[])
+        : [];
+      const mergedParams = [...pathLevelParams, ...opLevelParams];
+
+      // Extract request body schema (OpenAPI 3.x)
+      let requestBody: Record<string, unknown> | null = null;
+      if (op['requestBody'] && typeof op['requestBody'] === 'object') {
+        const rb = op['requestBody'] as Record<string, unknown>;
+        const content = rb['content'] as Record<string, unknown> | undefined;
+        if (content) {
+          // Prefer application/json
+          const jsonContent = content['application/json'] as Record<string, unknown> | undefined;
+          if (jsonContent?.['schema']) {
+            requestBody = jsonContent['schema'] as Record<string, unknown>;
+          }
+        }
+      }
+
+      // Extract 200/201 response schema
+      let responseSchema: Record<string, unknown> | null = null;
+      const responses = op['responses'] as Record<string, unknown> | undefined;
+      if (responses) {
+        const successResponse = (responses['200'] ?? responses['201']) as Record<string, unknown> | undefined;
+        if (successResponse) {
+          const content = successResponse['content'] as Record<string, unknown> | undefined;
+          if (content) {
+            const jsonContent = content['application/json'] as Record<string, unknown> | undefined;
+            if (jsonContent?.['schema']) {
+              responseSchema = jsonContent['schema'] as Record<string, unknown>;
+            }
+          }
+          // Swagger 2.x uses schema directly on the response
+          if (!responseSchema && successResponse['schema']) {
+            responseSchema = successResponse['schema'] as Record<string, unknown>;
+          }
+        }
+      }
+
+      const tags = Array.isArray(op['tags']) ? (op['tags'] as string[]) : [];
+
+      endpoints.push({
+        operationId: (op['operationId'] as string) ?? null,
+        method,
+        path: pathStr,
+        summary: (op['summary'] as string) ?? null,
+        description: (op['description'] as string) ?? null,
+        parameters: mergedParams.length > 0 ? mergedParams : null,
+        requestBody,
+        responseSchema,
+        tags,
+      });
+    }
+  }
+
+  return {
+    title: info.title,
+    version: info.version ?? null,
+    baseUrl,
+    endpoints,
+  };
+}
+
+/**
+ * Import parsed endpoints into the tool_registry table.
+ * Returns the created registry entries.
+ */
+export async function importEndpoints(
+  userId: string,
+  parsedSpec: ParsedSpec,
+  specUrl: string | null,
+  selectedPaths?: Array<{ method: string; path: string }>,
+): Promise<ToolRegistryEntry[]> {
+  const specId = crypto.randomUUID();
+
+  // Filter to selected endpoints if provided, otherwise import all
+  let endpointsToImport = parsedSpec.endpoints;
+  if (selectedPaths && selectedPaths.length > 0) {
+    const selectionSet = new Set(selectedPaths.map(s => `${s.method}:${s.path}`));
+    endpointsToImport = parsedSpec.endpoints.filter(
+      ep => selectionSet.has(`${ep.method}:${ep.path}`),
+    );
+  }
+
+  if (endpointsToImport.length === 0) {
+    return [];
+  }
+
+  const rows: NewToolRegistryEntry[] = endpointsToImport.map(ep => ({
+    userId,
+    specId,
+    specTitle: parsedSpec.title,
+    specVersion: parsedSpec.version,
+    specUrl,
+    baseUrl: parsedSpec.baseUrl,
+    operationId: ep.operationId,
+    method: ep.method,
+    path: ep.path,
+    summary: ep.summary,
+    description: ep.description,
+    parameters: ep.parameters,
+    requestBody: ep.requestBody,
+    responseSchema: ep.responseSchema,
+    tags: ep.tags,
+  }));
+
+  const inserted = await db.insert(toolRegistry).values(rows).returning();
+  return inserted;
+}
+
+/**
+ * List all tool registry entries for a user.
+ */
+export async function listToolRegistry(userId: string): Promise<ToolRegistryEntry[]> {
+  return db.select().from(toolRegistry).where(eq(toolRegistry.userId, userId));
+}
+
+/**
+ * Delete all endpoints for a given specId (unregister an entire imported spec).
+ */
+export async function deleteSpec(userId: string, specId: string): Promise<number> {
+  const result = await db
+    .delete(toolRegistry)
+    .where(and(eq(toolRegistry.userId, userId), eq(toolRegistry.specId, specId)))
+    .returning();
+  return result.length;
+}
+
+/**
+ * Toggle isEnabled for a specific registry entry.
+ */
+export async function toggleEndpoint(
+  userId: string,
+  entryId: string,
+  isEnabled: boolean,
+): Promise<ToolRegistryEntry | null> {
+  const [updated] = await db
+    .update(toolRegistry)
+    .set({ isEnabled, updatedAt: new Date() })
+    .where(and(eq(toolRegistry.id, entryId), eq(toolRegistry.userId, userId)))
+    .returning();
+  return updated ?? null;
+}

--- a/services/ui/src/routes/(app)/tools/+layout.svelte
+++ b/services/ui/src/routes/(app)/tools/+layout.svelte
@@ -20,6 +20,7 @@
   const toolsTabs = [
     { href: '/tools/catalog', label: 'CATALOG' },
     { href: '/tools/belt', label: 'MY TOOLS' },
+    { href: '/tools/import', label: 'IMPORT' },
     { href: '/tools/webhooks', label: 'WEBHOOKS' },
   ] as const;
 

--- a/services/ui/src/routes/(app)/tools/import/+page.server.ts
+++ b/services/ui/src/routes/(app)/tools/import/+page.server.ts
@@ -1,0 +1,20 @@
+import type { PageServerLoad } from './$types';
+import { error } from '@sveltejs/kit';
+
+export const load: PageServerLoad = async ({ fetch, parent }) => {
+  const { session } = await parent();
+  if (!session) throw error(401, 'Not authenticated');
+  const userId = session.user?.id;
+  if (!userId) throw error(401, 'No user ID in session');
+
+  // Fetch existing imported tools for the registry list
+  const [registryRes] = await Promise.allSettled([
+    fetch(`/api/akasa/tool-registry?userId=${encodeURIComponent(userId)}`),
+  ]);
+
+  const registry = registryRes.status === 'fulfilled' && registryRes.value.ok
+    ? await registryRes.value.json()
+    : [];
+
+  return { userId, registry };
+};

--- a/services/ui/src/routes/(app)/tools/import/+page.svelte
+++ b/services/ui/src/routes/(app)/tools/import/+page.svelte
@@ -1,0 +1,746 @@
+<script lang="ts">
+  import { invalidateAll } from '$app/navigation';
+
+  let { data } = $props();
+
+  // ── Import form state ──────────────────────────────────────────────
+  let specUrl = $state('');
+  let loading = $state(false);
+  let errorMsg = $state<string | null>(null);
+  let successMsg = $state<string | null>(null);
+
+  // ── Preview state ──────────────────────────────────────────────────
+  interface PreviewEndpoint {
+    operationId: string | null;
+    method: string;
+    path: string;
+    summary: string | null;
+    description: string | null;
+    tags: string[];
+    selected: boolean;
+  }
+
+  let previewTitle = $state('');
+  let previewVersion = $state('');
+  let previewBaseUrl = $state('');
+  let previewEndpoints = $state<PreviewEndpoint[]>([]);
+  let showPreview = $state(false);
+  let importing = $state(false);
+
+  // ── Grouped registry entries by specId ─────────────────────────────
+  interface RegistryEntry {
+    id: string;
+    specId: string;
+    specTitle: string;
+    specVersion: string | null;
+    specUrl: string | null;
+    baseUrl: string;
+    operationId: string | null;
+    method: string;
+    path: string;
+    summary: string | null;
+    description: string | null;
+    tags: string[] | null;
+    isEnabled: boolean;
+    createdAt: string;
+  }
+
+  interface SpecGroup {
+    specId: string;
+    specTitle: string;
+    specVersion: string | null;
+    specUrl: string | null;
+    baseUrl: string;
+    endpoints: RegistryEntry[];
+    expanded: boolean;
+  }
+
+  let specGroups = $derived.by(() => {
+    const entries = data.registry as RegistryEntry[];
+    const groupMap = new Map<string, SpecGroup>();
+    for (const entry of entries) {
+      if (!groupMap.has(entry.specId)) {
+        groupMap.set(entry.specId, {
+          specId: entry.specId,
+          specTitle: entry.specTitle,
+          specVersion: entry.specVersion,
+          specUrl: entry.specUrl,
+          baseUrl: entry.baseUrl,
+          endpoints: [],
+          expanded: false,
+        });
+      }
+      groupMap.get(entry.specId)!.endpoints.push(entry);
+    }
+    return Array.from(groupMap.values());
+  });
+
+  const allSelected = $derived(previewEndpoints.length > 0 && previewEndpoints.every(e => e.selected));
+  const noneSelected = $derived(previewEndpoints.every(e => !e.selected));
+  const selectedCount = $derived(previewEndpoints.filter(e => e.selected).length);
+
+  // ── Actions ────────────────────────────────────────────────────────
+
+  async function handlePreview() {
+    if (!specUrl.trim()) return;
+
+    loading = true;
+    errorMsg = null;
+    showPreview = false;
+
+    try {
+      const res = await fetch('/api/akasa/tool-registry/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ specUrl: specUrl.trim() }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: 'Unknown error' }));
+        errorMsg = body.error ?? `Failed to parse spec (${res.status})`;
+        return;
+      }
+
+      const parsed = await res.json();
+      previewTitle = parsed.title;
+      previewVersion = parsed.version ?? '';
+      previewBaseUrl = parsed.baseUrl;
+      previewEndpoints = parsed.endpoints.map((ep: PreviewEndpoint) => ({
+        ...ep,
+        selected: true,
+      }));
+      showPreview = true;
+    } catch (err) {
+      errorMsg = `Network error: ${(err as Error).message}`;
+    } finally {
+      loading = false;
+    }
+  }
+
+  function toggleAll() {
+    const newVal = !allSelected;
+    previewEndpoints = previewEndpoints.map(e => ({ ...e, selected: newVal }));
+  }
+
+  function toggleEndpoint(index: number) {
+    previewEndpoints = previewEndpoints.map((e, i) =>
+      i === index ? { ...e, selected: !e.selected } : e
+    );
+  }
+
+  async function handleImport() {
+    if (noneSelected) return;
+
+    importing = true;
+    errorMsg = null;
+
+    const selectedEndpoints = previewEndpoints
+      .filter(e => e.selected)
+      .map(e => ({ method: e.method, path: e.path }));
+
+    try {
+      const res = await fetch('/api/akasa/tool-registry/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          userId: data.userId,
+          specUrl: specUrl.trim(),
+          selectedEndpoints,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: 'Unknown error' }));
+        errorMsg = body.error ?? `Import failed (${res.status})`;
+        return;
+      }
+
+      const imported = await res.json();
+      successMsg = `Imported ${imported.length} endpoint${imported.length === 1 ? '' : 's'} from ${previewTitle}`;
+      showPreview = false;
+      specUrl = '';
+      previewEndpoints = [];
+
+      // Refresh registry list
+      await invalidateAll();
+
+      setTimeout(() => { successMsg = null; }, 4000);
+    } catch (err) {
+      errorMsg = `Network error: ${(err as Error).message}`;
+    } finally {
+      importing = false;
+    }
+  }
+
+  async function handleDeleteSpec(specId: string) {
+    try {
+      const res = await fetch(`/api/akasa/tool-registry/${specId}?userId=${encodeURIComponent(data.userId)}`, {
+        method: 'DELETE',
+      });
+      if (res.ok) {
+        await invalidateAll();
+      } else {
+        errorMsg = 'Failed to remove imported spec';
+        setTimeout(() => { errorMsg = null; }, 4000);
+      }
+    } catch {
+      errorMsg = 'Failed to remove imported spec';
+      setTimeout(() => { errorMsg = null; }, 4000);
+    }
+  }
+
+  async function handleToggleEndpoint(entryId: string, currentEnabled: boolean) {
+    try {
+      await fetch(`/api/akasa/tool-registry/${entryId}/toggle`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: data.userId, isEnabled: !currentEnabled }),
+      });
+      await invalidateAll();
+    } catch {
+      errorMsg = 'Failed to toggle endpoint';
+      setTimeout(() => { errorMsg = null; }, 4000);
+    }
+  }
+
+  function toggleGroup(specId: string) {
+    const group = specGroups.find(g => g.specId === specId);
+    if (group) {
+      group.expanded = !group.expanded;
+    }
+  }
+
+  function methodColor(method: string): string {
+    switch (method.toLowerCase()) {
+      case 'get': return 'var(--bo-teal, #2DD4BF)';
+      case 'post': return 'var(--bo-amber, #FBBF24)';
+      case 'put': return 'var(--bo-vb, #A78BFA)';
+      case 'patch': return 'var(--bo-rose, #F472B6)';
+      case 'delete': return 'var(--error, #f87171)';
+      default: return 'var(--text-muted)';
+    }
+  }
+</script>
+
+<div class="import-page">
+  {#if successMsg}
+    <div class="banner banner-success">{successMsg}</div>
+  {/if}
+  {#if errorMsg}
+    <div class="banner banner-error">{errorMsg}</div>
+  {/if}
+
+  <!-- Import Form -->
+  <section class="import-section">
+    <h2 class="section-heading">Import OpenAPI Spec</h2>
+    <p class="section-desc">Paste a URL to an OpenAPI or Swagger specification to auto-discover and register tool endpoints.</p>
+
+    <div class="import-form">
+      <input
+        type="url"
+        class="spec-input"
+        placeholder="https://api.example.com/openapi.json"
+        bind:value={specUrl}
+        onkeydown={(e) => { if (e.key === 'Enter') handlePreview(); }}
+        disabled={loading}
+      />
+      <button
+        class="btn btn-preview"
+        onclick={handlePreview}
+        disabled={loading || !specUrl.trim()}
+      >
+        {loading ? 'Parsing...' : 'Preview'}
+      </button>
+    </div>
+  </section>
+
+  <!-- Preview Panel -->
+  {#if showPreview}
+    <section class="preview-section">
+      <div class="preview-header">
+        <div class="preview-meta">
+          <h3 class="preview-title">{previewTitle}</h3>
+          {#if previewVersion}
+            <span class="preview-version">v{previewVersion}</span>
+          {/if}
+          <span class="preview-base">{previewBaseUrl}</span>
+        </div>
+        <div class="preview-actions">
+          <button class="btn btn-toggle-all" onclick={toggleAll}>
+            {allSelected ? 'Deselect All' : 'Select All'}
+          </button>
+          <button
+            class="btn btn-import"
+            onclick={handleImport}
+            disabled={importing || noneSelected}
+          >
+            {importing ? 'Importing...' : `Import ${selectedCount} endpoint${selectedCount === 1 ? '' : 's'}`}
+          </button>
+        </div>
+      </div>
+
+      <div class="endpoint-list">
+        {#each previewEndpoints as ep, i}
+          <button
+            class="endpoint-row"
+            class:deselected={!ep.selected}
+            onclick={() => toggleEndpoint(i)}
+          >
+            <span class="endpoint-check">{ep.selected ? '\u2611' : '\u2610'}</span>
+            <span class="endpoint-method" style="color: {methodColor(ep.method)}">{ep.method.toUpperCase()}</span>
+            <span class="endpoint-path">{ep.path}</span>
+            {#if ep.summary}
+              <span class="endpoint-summary">{ep.summary}</span>
+            {/if}
+            {#each ep.tags as tag}
+              <span class="endpoint-tag">{tag}</span>
+            {/each}
+          </button>
+        {/each}
+      </div>
+    </section>
+  {/if}
+
+  <!-- Imported Tools Registry -->
+  {#if specGroups.length > 0}
+    <section class="registry-section">
+      <h2 class="section-heading">Imported Tools</h2>
+
+      {#each specGroups as group}
+        <div class="spec-group">
+          <button class="spec-group-header" onclick={() => toggleGroup(group.specId)}>
+            <div class="spec-group-meta">
+              <span class="spec-group-title">{group.specTitle}</span>
+              {#if group.specVersion}
+                <span class="spec-group-version">v{group.specVersion}</span>
+              {/if}
+              <span class="spec-group-count">{group.endpoints.length} endpoint{group.endpoints.length === 1 ? '' : 's'}</span>
+            </div>
+            <div class="spec-group-actions">
+              <button
+                class="btn btn-remove"
+                onclick|stopPropagation={() => handleDeleteSpec(group.specId)}
+              >
+                Remove
+              </button>
+              <span class="expand-icon">{group.expanded ? '\u25BC' : '\u25B6'}</span>
+            </div>
+          </button>
+
+          {#if group.expanded}
+            <div class="spec-group-body">
+              {#each group.endpoints as entry}
+                <div class="registry-row" class:disabled-row={!entry.isEnabled}>
+                  <span class="endpoint-method" style="color: {methodColor(entry.method)}">{entry.method.toUpperCase()}</span>
+                  <span class="endpoint-path">{entry.path}</span>
+                  {#if entry.summary}
+                    <span class="endpoint-summary">{entry.summary}</span>
+                  {/if}
+                  <button
+                    class="btn btn-toggle-endpoint"
+                    onclick={() => handleToggleEndpoint(entry.id, entry.isEnabled)}
+                  >
+                    {entry.isEnabled ? 'Disable' : 'Enable'}
+                  </button>
+                </div>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {/each}
+    </section>
+  {/if}
+</div>
+
+<style>
+  .import-page {
+    padding: var(--space-2xl) var(--space-xl);
+    max-width: 960px;
+  }
+
+  .banner {
+    margin-bottom: var(--space-lg);
+    padding: var(--space-md) var(--space-lg);
+    border-radius: var(--radius-md);
+    font-family: var(--font-body);
+    font-size: 13px;
+    font-weight: 400;
+    background: var(--card);
+    line-height: 1.5;
+  }
+
+  .banner-success {
+    border: 1px solid var(--success, #2DD4BF);
+    color: var(--success, #2DD4BF);
+  }
+
+  .banner-error {
+    border: 1px solid var(--error);
+    color: var(--error);
+  }
+
+  /* ── Section headings ──────────────────────────────────── */
+
+  .section-heading {
+    font-family: var(--font-display);
+    font-size: 22px;
+    font-weight: 600;
+    color: var(--text);
+    margin: 0 0 var(--space-xs) 0;
+    line-height: 1.2;
+  }
+
+  .section-desc {
+    font-family: var(--font-body);
+    font-size: 13px;
+    color: var(--text-muted);
+    margin: 0 0 var(--space-lg) 0;
+    line-height: 1.5;
+  }
+
+  /* ── Import form ───────────────────────────────────────── */
+
+  .import-section {
+    margin-bottom: var(--space-2xl);
+  }
+
+  .import-form {
+    display: flex;
+    gap: var(--space-sm);
+  }
+
+  .spec-input {
+    flex: 1;
+    min-height: 44px;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: 0 var(--space-lg);
+    font-family: var(--font-body);
+    font-size: 13px;
+    color: var(--text);
+    outline: none;
+    transition: border-color 0.15s ease;
+  }
+
+  .spec-input::placeholder {
+    color: var(--text-muted);
+    opacity: 0.6;
+  }
+
+  .spec-input:focus {
+    border-color: var(--accent);
+  }
+
+  .spec-input:disabled {
+    opacity: 0.5;
+  }
+
+  /* ── Buttons ───────────────────────────────────────────── */
+
+  .btn {
+    min-height: 44px;
+    font-family: var(--font-body);
+    font-size: 13px;
+    font-weight: 400;
+    background: transparent;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: background 0.15s ease, opacity 0.15s ease;
+    padding: 0 var(--space-lg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
+  }
+
+  .btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .btn-preview {
+    border: 1px solid var(--accent);
+    color: var(--accent);
+  }
+
+  .btn-preview:hover:not(:disabled) {
+    background: var(--accent-dim);
+  }
+
+  .btn-import {
+    border: 1px solid var(--rose, #F472B6);
+    color: var(--rose, #F472B6);
+  }
+
+  .btn-import:hover:not(:disabled) {
+    background: rgba(244, 114, 182, 0.08);
+  }
+
+  .btn-toggle-all {
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    min-height: 36px;
+    font-size: 12px;
+  }
+
+  .btn-toggle-all:hover {
+    border-color: var(--accent);
+    color: var(--text);
+  }
+
+  .btn-remove {
+    border: 1px solid var(--error);
+    color: var(--error);
+    min-height: 32px;
+    font-size: 12px;
+    padding: 0 var(--space-md);
+  }
+
+  .btn-remove:hover {
+    background: var(--error-dim);
+  }
+
+  .btn-toggle-endpoint {
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    min-height: 28px;
+    font-size: 11px;
+    padding: 0 var(--space-sm);
+    margin-left: auto;
+    flex-shrink: 0;
+  }
+
+  .btn-toggle-endpoint:hover {
+    border-color: var(--accent);
+    color: var(--text);
+  }
+
+  /* ── Preview panel ─────────────────────────────────────── */
+
+  .preview-section {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    margin-bottom: var(--space-2xl);
+    overflow: hidden;
+  }
+
+  .preview-header {
+    padding: var(--space-lg);
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--space-md);
+  }
+
+  .preview-meta {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-sm);
+    flex-wrap: wrap;
+  }
+
+  .preview-title {
+    font-family: var(--font-body);
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text);
+    margin: 0;
+  }
+
+  .preview-version {
+    font-family: var(--font-label);
+    font-size: 6px;
+    color: var(--accent);
+    letter-spacing: 0.08em;
+  }
+
+  .preview-base {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+
+  .preview-actions {
+    display: flex;
+    gap: var(--space-sm);
+  }
+
+  .endpoint-list {
+    max-height: 440px;
+    overflow-y: auto;
+  }
+
+  .endpoint-row {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: var(--space-sm) var(--space-lg);
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-family: var(--font-body);
+    font-size: 13px;
+    color: var(--text);
+    text-align: left;
+    transition: background 0.1s ease;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .endpoint-row:last-child {
+    border-bottom: none;
+  }
+
+  .endpoint-row:hover {
+    background: var(--accent-dim);
+  }
+
+  .endpoint-row.deselected {
+    opacity: 0.4;
+  }
+
+  .endpoint-check {
+    font-size: 16px;
+    color: var(--accent);
+    flex-shrink: 0;
+    width: 20px;
+  }
+
+  .endpoint-method {
+    font-family: var(--font-label);
+    font-size: 7px;
+    letter-spacing: 0.06em;
+    flex-shrink: 0;
+    width: 52px;
+    text-align: left;
+  }
+
+  .endpoint-path {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text);
+    flex-shrink: 0;
+  }
+
+  .endpoint-summary {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-left: var(--space-sm);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .endpoint-tag {
+    font-family: var(--font-label);
+    font-size: 6px;
+    color: var(--text-muted);
+    background: var(--accent-dim);
+    padding: 2px 6px;
+    border-radius: var(--radius-sm);
+    letter-spacing: 0.06em;
+    flex-shrink: 0;
+  }
+
+  /* ── Registry list ─────────────────────────────────────── */
+
+  .registry-section {
+    margin-bottom: var(--space-2xl);
+  }
+
+  .registry-section .section-heading {
+    margin-bottom: var(--space-lg);
+  }
+
+  .spec-group {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    margin-bottom: var(--space-md);
+    overflow: hidden;
+  }
+
+  .spec-group-header {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-md) var(--space-lg);
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-family: var(--font-body);
+    color: var(--text);
+    text-align: left;
+    transition: background 0.1s ease;
+  }
+
+  .spec-group-header:hover {
+    background: var(--accent-dim);
+  }
+
+  .spec-group-meta {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-sm);
+    flex-wrap: wrap;
+  }
+
+  .spec-group-title {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text);
+  }
+
+  .spec-group-version {
+    font-family: var(--font-label);
+    font-size: 6px;
+    color: var(--accent);
+    letter-spacing: 0.08em;
+  }
+
+  .spec-group-count {
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+
+  .spec-group-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+  }
+
+  .expand-icon {
+    font-size: 10px;
+    color: var(--text-muted);
+  }
+
+  .spec-group-body {
+    border-top: 1px solid var(--border);
+  }
+
+  .registry-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: var(--space-sm) var(--space-lg);
+    border-bottom: 1px solid var(--border);
+    font-family: var(--font-body);
+    font-size: 13px;
+    color: var(--text);
+  }
+
+  .registry-row:last-child {
+    border-bottom: none;
+  }
+
+  .registry-row.disabled-row {
+    opacity: 0.4;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Wires up the OpenAPI/Swagger import feature end-to-end: backend service, Express routes, DB schema, migration, and frontend UI
- Installs `@apidevtools/swagger-parser` in akasa-server for spec parsing with `$ref` dereferencing
- Exports `toolRegistry` table from `@claw/db` barrel and registers missing migrations (0018-0020) in the journal
- Mounts `toolRegistryRouter` at `/akasa/tool-registry` in akasa-server route index
- Adds "IMPORT" tab to tools layout navigation, linking to the existing import page with URL input, endpoint preview, and confirm import flow
- Fixes Express 5 type narrowing on `req.params` in tool-registry route handlers

## How it works
1. User pastes an OpenAPI spec URL on the Import tab
2. `POST /akasa/tool-registry/preview` parses and dereferences the spec, returns discovered endpoints
3. User selects which endpoints to import and confirms
4. `POST /akasa/tool-registry/import` persists selected endpoints to `tool_registry` table
5. `GET /akasa/tool-registry` lists imported tools; `DELETE` and `PATCH /toggle` manage them

## Test plan
- [ ] Run migration `0020_tool_registry.sql` against local DB
- [ ] Start akasa-server and verify `/akasa/tool-registry/preview` accepts a spec URL
- [ ] Verify endpoint selection and import flow persists to DB
- [ ] Verify imported tools appear in the registry list on the Import tab
- [ ] Verify disable/enable toggle and spec removal work

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)