### PR TITLE
docs: Add GitHub issue templates for AI-agent workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,104 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Bug Report
+        Help us fix it by providing as much detail as possible.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear summary of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happens?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected-services
+    attributes:
+      label: Affected Services
+      description: Which parts of the system are affected?
+      multiple: true
+      options:
+        - execution-service
+        - tool-gateway
+        - telegram-bot
+        - ui
+        - db (schema/migrations)
+        - shared-types
+        - event-schemas
+        - tool-contracts
+        - infra
+    validations:
+      required: true
+
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain
+      options:
+        - domain:backend
+        - domain:frontend
+        - domain:database
+        - domain:infra
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - priority:medium
+        - priority:high
+        - priority:critical
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, browser, Node version, or any relevant environment details.
+      placeholder: "macOS 15, Chrome 130, Node 22.x, local dev"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Screenshots
+      description: Paste any relevant error output or attach screenshots.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Product Requirements
+    url: https://github.com/tarikstafford/claw-army/tree/main/tasks
+    about: Browse existing PRDs and product planning docs

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,91 @@
+name: Feature Request
+description: Propose a new feature or capability
+labels: ["type:feature", "enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## New Feature Request
+        Describe the feature you'd like to add to Akasa.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What should this feature do? Include context on the user problem it solves.
+      placeholder: "As a user, I want to ... so that ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What conditions must be met for this feature to be considered complete?
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected-services
+    attributes:
+      label: Affected Services
+      description: Which parts of the system does this touch?
+      multiple: true
+      options:
+        - execution-service
+        - tool-gateway
+        - telegram-bot
+        - ui
+        - db (schema/migrations)
+        - shared-types
+        - event-schemas
+        - tool-contracts
+        - infra
+    validations:
+      required: true
+
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain
+      description: Primary domain label
+      options:
+        - domain:backend
+        - domain:frontend
+        - domain:database
+        - domain:infra
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort Estimate
+      options:
+        - effort:small
+        - effort:medium
+        - effort:large
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - priority:medium
+        - priority:high
+        - priority:critical
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any mockups, links, or references that help clarify the request.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/techdebt.yml
+++ b/.github/ISSUE_TEMPLATE/techdebt.yml
@@ -1,0 +1,86 @@
+name: Technical Debt
+description: Track technical debt cleanup or refactoring work
+labels: ["type:techdebt"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Technical Debt
+        Describe the debt and why it matters to address it.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: What is the technical debt? Be specific about files, patterns, or modules.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: Why should we fix this? What risk or friction does it cause?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Which parts of the system are affected?
+      multiple: true
+      options:
+        - execution-service
+        - tool-gateway
+        - telegram-bot
+        - ui
+        - db (schema/migrations)
+        - shared-types
+        - event-schemas
+        - tool-contracts
+        - infra
+    validations:
+      required: true
+
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain
+      options:
+        - domain:backend
+        - domain:frontend
+        - domain:database
+        - domain:infra
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort Estimate
+      options:
+        - effort:small
+        - effort:medium
+        - effort:large
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - priority:medium
+        - priority:high
+        - priority:critical
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposed-approach
+    attributes:
+      label: Proposed Approach
+      description: How would you tackle this? Optional but helpful for AI agents picking up the work.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/test.yml
+++ b/.github/ISSUE_TEMPLATE/test.yml
@@ -1,0 +1,75 @@
+name: Test Addition
+description: Track missing or needed test coverage
+labels: ["type:test"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Test Addition
+        Describe the test coverage that needs to be added.
+
+  - type: textarea
+    id: modules
+    attributes:
+      label: Modules to Test
+      description: Which modules, services, or functions need test coverage?
+      placeholder: |
+        - services/execution-service/src/services/council.ts
+        - services/execution-service/src/services/god-layer.ts
+    validations:
+      required: true
+
+  - type: dropdown
+    id: test-type
+    attributes:
+      label: Test Type
+      description: What kind of tests are needed?
+      multiple: true
+      options:
+        - Unit tests
+        - Integration tests
+        - E2E tests
+    validations:
+      required: true
+
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain
+      options:
+        - domain:backend
+        - domain:frontend
+        - domain:database
+        - domain:infra
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - priority:medium
+        - priority:high
+        - priority:critical
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort Estimate
+      options:
+        - effort:small
+        - effort:medium
+        - effort:large
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Any context on what to assert, edge cases, or testing strategy.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Adds YAML form-based issue templates (feature, bug, techdebt, test) in `.github/ISSUE_TEMPLATE/`
- Templates use the repo's existing label conventions (`domain:*`, `type:*`, `effort:*`, `priority:*`) for consistent issue triage
- Disables blank issues via `config.yml` to enforce structured input from both humans and AI agents

## Test plan
- [ ] Navigate to repo > Issues > New Issue and verify the template chooser shows all four templates
- [ ] Open each template and confirm all form fields render correctly
- [ ] Submit a test issue from one template and verify labels are auto-applied

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)