### PR TITLE
chore: document all environment variables in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,214 @@
+# ── Shared Infrastructure ─────────────────────────────────────────────────────
+# PostgreSQL connection string (used by all services and packages/db)
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/clawdb
+
+# Redis URL for BullMQ task queues and guardrail rate limiting
 REDIS_URL=redis://localhost:6379
+
+# GCP project ID for Pub/Sub, Compute Engine, and Secret Manager
 GCP_PROJECT_ID=claw-army-dev
+
+# Pub/Sub emulator host (local dev only — unset in production)
 PUBSUB_EMULATOR_HOST=localhost:8085
+
+# Node environment
+NODE_ENV=development
+
+
+# ── Execution Service (services/execution-service) ───────────────────────────
+# Server port (default: 3001)
+# PORT=3001
+
+# Pino log level: trace | debug | info | warn | error | fatal
+# LOG_LEVEL=info
+
+# Auth.js secret — must match the UI's AUTH_SECRET
+AUTH_SECRET=your-secret-here
+
+# CORS origin for browser requests (default: http://localhost:5173)
+CORS_ORIGIN=http://localhost:5173
+
+# JWT secret for signing bot session tokens (must match tool-gateway)
+BOT_JWT_SECRET=your-bot-jwt-secret
+
+# Internal API key for CLI/script access bypassing Auth.js (optional, not for production)
+# INTERNAL_API_KEY=
+
+# ── GCP / VM Orchestration (required in production) ──────────────────────────
+# Compute Engine zone for bot VMs
+GCP_ZONE=us-central1-a
+
+# VPC network and subnet for bot VMs
+GCP_NETWORK=default
+GCP_SUBNET=default
+
+# Service account email attached to bot VMs
+GCP_BOT_SERVICE_ACCOUNT=bot-vm@your-project.iam.gserviceaccount.com
+
+# Secret Manager secret name containing the LLM API key
+LLM_API_KEY_SECRET_NAME=llm-api-key
+
+# LLM provider for bot VMs (e.g. anthropic, openai)
+# LLM_PROVIDER=anthropic
+
+# Tool Gateway URL injected into bot VMs as HTTP_PROXY
+TOOL_GATEWAY_VPC_URL=http://10.0.0.3:3002
+
+# Tool Gateway URL used by execution-service itself
+TOOL_GATEWAY_URL=http://localhost:3002
+
+# ── Pub/Sub Topics ───────────────────────────────────────────────────────────
+# All optional — defaults to the name shown
+# BOT_LIFECYCLE_TOPIC=bot-lifecycle
+# TASK_LIFECYCLE_TOPIC=task-lifecycle
+# EXECUTION_LIFECYCLE_TOPIC=execution-lifecycle
+# GUARDRAIL_EVENTS_TOPIC=guardrail-events
+# BILLING_EVENTS_TOPIC=billing-events
+# SOUL_LIFECYCLE_TOPIC=soul-lifecycle
+# RING_LEADER_EVENTS_TOPIC=ring-leader-events
+
+# Pub/Sub subscriptions (optional — defaults to the name shown)
+# BOT_LIFECYCLE_SUBSCRIPTION=bot-lifecycle-sub
+# BILLING_SUBSCRIPTION=billing-sub
+
+# ── Timeouts (milliseconds) ─────────────────────────────────────────────────
+# Max time to wait for a bot to become ready (default: 600000 = 10 min)
+# BOT_WAIT_TIMEOUT_MS=600000
+
+# Max time for a single task execution (default: 1800000 = 30 min)
+# TASK_EXECUTION_TIMEOUT_MS=1800000
+
+# VM spawn health-check interval and timeout
+# SPAWN_CHECK_INTERVAL_MS=5000
+# SPAWN_TIMEOUT_MS=300000
+
+# Idle bot detection interval and threshold
+# IDLE_CHECK_INTERVAL_MS=60000
+# IDLE_TIMEOUT_MS=300000
+
+# Watchdog interval for stale execution detection
+# WATCHDOG_INTERVAL_MS=60000
+
+# ── Billing / Stripe ────────────────────────────────────────────────────────
+# Stripe secret key (metered billing — display only, no real charges yet)
+# STRIPE_SECRET_KEY=sk_test_...
+
+# Stripe webhook secret for verifying inbound webhook signatures
+# STRIPE_WEBHOOK_SECRET=whsec_...
+
+# Stripe metered product IDs
+# STRIPE_BOT_HOURS_PRODUCT_ID=
+# STRIPE_LLM_INPUT_PRODUCT_ID=
+# STRIPE_LLM_OUTPUT_PRODUCT_ID=
+# STRIPE_TOOL_INVOCATIONS_PRODUCT_ID=
+
+# Billing rates (cents per unit)
+LLM_INPUT_RATE_CENTS_PER_M=300
+LLM_OUTPUT_RATE_CENTS_PER_M=1500
+BOT_HOURLY_RATE_CENTS=50
+
+# ── Evolution Engine Tuning ─────────────────────────────────────────────────
+# Composite score weights (must sum to 1.0 — defaults shown)
+# SCORE_WEIGHT_SUCCESS=0.4
+# SCORE_WEIGHT_EFFICIENCY=0.25
+# SCORE_WEIGHT_COST=0.15
+# SCORE_WEIGHT_STABILITY=0.2
+
+# DNA capture thresholds
+# DNA_ELITE_THRESHOLD=0.85
+# DNA_ABOVE_AVERAGE_PCT=65
+# DNA_ERROR_RATE_CEILING=0.15
+
+# Performance tier thresholds
+# TIER_HIGH_THRESHOLD=0.75
+# TIER_MEDIUM_THRESHOLD=0.45
+
+# ── Council / Planner LLM Models ────────────────────────────────────────────
+# Model IDs for council scoring, planning, and synthesis (optional — defaults are built-in)
+# COORDINATION_SCORER_MODEL=
+# SOUL_SELECTION_SCORER_MODEL=
+# PLANNER_MODEL=
+# SYNTHESIS_MODEL=
+
+# Coordination loop poll interval (default: 30000 = 30s)
+# COORDINATION_POLL_INTERVAL_MS=30000
+
+# ── Guardrail Tuning ────────────────────────────────────────────────────────
+# TTL in seconds for guardrail deny entries in Redis (default: 300)
+# GUARDRAIL_DENY_TTL_SECONDS=300
+
+# Number of recent events to check for loop detection
+# LOOP_DETECTION_WINDOW=5
+
+
+# ── Tool Gateway (services/tool-gateway) ─────────────────────────────────────
+# Server port (default: 3002)
+# PORT=3002
+
+# Comma-separated domain allowlist for bot egress
+# Empty = allow all (development only; restrict in production)
+# Example: api.anthropic.com,api.openai.com,generativelanguage.googleapis.com
+PROXY_DOMAIN_ALLOWLIST=
+
+# JWT secret for bot authentication (must match execution-service BOT_JWT_SECRET)
+# BOT_JWT_SECRET is shared — set it once above
+
+
+# ── Akasa Server (services/akasa-server) ─────────────────────────────────────
+# Secret for deriving deterministic webhook URLs. Must be stable across restarts.
+# Generate with: openssl rand -hex 32
+WEBHOOK_URL_SECRET=
+
+# AES-256-GCM key for encrypting OAuth tokens in tool_connections table
+# Generate with: openssl rand -base64 32
+# Falls back to PAPERCLIP_SECRETS_MASTER_KEY if unset
+TOOL_ENCRYPTION_KEY=
+
+# Paperclip master encryption key (fallback for TOOL_ENCRYPTION_KEY)
+PAPERCLIP_SECRETS_MASTER_KEY=
+
+# Base URL for OAuth callback redirects
+# In production, set to the public URL where SvelteKit is served
+AKASA_BASE_URL=http://localhost:5173
+
+# Execution service URL (used by akasa-server command routing)
+EXECUTION_SERVICE_URL=http://localhost:3001
+
+# ── OAuth Provider Credentials (Tool Nexus) ──────────────────────────────────
+HUBSPOT_CLIENT_ID=
+HUBSPOT_CLIENT_SECRET=
+SLACK_CLIENT_ID=
+SLACK_CLIENT_SECRET=
+SLACK_SIGNING_SECRET=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+GITHUB_WEBHOOK_SECRET=
+LINEAR_WEBHOOK_SECRET=
+
+# Stripe webhook secret (also used by akasa-server webhook verification)
+# STRIPE_WEBHOOK_SECRET is shared — set it once above
+
+
+# ── UI / SvelteKit (services/ui) ─────────────────────────────────────────────
+# Auth.js secret — must match execution-service's AUTH_SECRET
+# AUTH_SECRET is shared — set it once above
+
+# Google OAuth credentials for user login
+# Set up at: Google Cloud Console -> APIs & Services -> Credentials
+# Authorized redirect URI for local dev: http://localhost:5173/auth/callback/google
+AUTH_GOOGLE_ID=your-google-client-id
+AUTH_GOOGLE_SECRET=your-google-client-secret
+
+# Required for non-Vercel environments (local dev)
+AUTH_TRUST_HOST=true
+
+# Execution service URL for server-side API proxy
+# EXECUTION_SERVICE_URL is shared — set it once above
+
+
+# ── Stub Bot (services/stub-bot — dev/testing only) ──────────────────────────
+# These are injected by the orchestrator when spawning a bot; set manually for local testing
+# BOT_ID=
+# EXECUTION_ID=

--- a/services/akasa-server/.env.example
+++ b/services/akasa-server/.env.example
@@ -1,27 +1,32 @@
-# ─── Required ─────────────────────────────────────────────────────────────────
-# Postgres connection string (used by both Paperclip and Akasa)
+# ── Akasa Server ──────────────────────────────────────────────────────────────
+# Paperclip-integrated backend: Tool Nexus OAuth, webhooks, evolution triggers
+
+# ── Required ─────────────────────────────────────────────────────────────────
+# Postgres connection string (shared with Paperclip)
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/clawdb
 
 # Secret for deriving deterministic webhook URLs. Must be stable across restarts.
 # Generate with: openssl rand -hex 32
 WEBHOOK_URL_SECRET=
 
-# AES-256-GCM key for encrypting OAuth tokens in tool_connections table.
+# AES-256-GCM key for encrypting OAuth tokens in tool_connections table
 # Generate with: openssl rand -base64 32
-# Falls back to PAPERCLIP_SECRETS_MASTER_KEY if unset.
+# Falls back to PAPERCLIP_SECRETS_MASTER_KEY if unset
 TOOL_ENCRYPTION_KEY=
 
-# Paperclip master encryption key. Used as fallback for TOOL_ENCRYPTION_KEY.
+# Paperclip master encryption key (fallback for TOOL_ENCRYPTION_KEY)
 PAPERCLIP_SECRETS_MASTER_KEY=
 
-# Base URL for OAuth callback redirects (e.g. https://akasa.example.com).
-# Tool Nexus OAuth flows redirect to {AKASA_BASE_URL}/api/akasa/oauth/callback.
-# In development, defaults to http://localhost:5173 (SvelteKit dev server).
-# In production, MUST be set to the public URL where the SvelteKit UI is served,
-# otherwise OAuth callbacks will fail.
+# Base URL for OAuth callback redirects (e.g. https://akasa.example.com)
+# Tool Nexus OAuth flows redirect to {AKASA_BASE_URL}/tools/callback
+# In development, defaults to http://localhost:5173 (SvelteKit dev server)
+# In production, MUST be set to the public URL where the SvelteKit UI is served
 AKASA_BASE_URL=http://localhost:5173
 
-# ─── OAuth Provider Credentials (required for Tool Nexus) ─────────────────────
+# Execution service URL (used by command routing)
+EXECUTION_SERVICE_URL=http://localhost:3001
+
+# ── OAuth Provider Credentials (required for Tool Nexus) ─────────────────────
 HUBSPOT_CLIENT_ID=
 HUBSPOT_CLIENT_SECRET=
 SLACK_CLIENT_ID=
@@ -29,10 +34,18 @@ SLACK_CLIENT_SECRET=
 SLACK_SIGNING_SECRET=
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
 
-# ─── Optional ─────────────────────────────────────────────────────────────────
-# Redis URL for BullMQ queues (defaults to redis://localhost:6379)
+# ── Webhook Verification Secrets ─────────────────────────────────────────────
+# Provider-specific secrets for verifying inbound webhook signatures
+GITHUB_WEBHOOK_SECRET=
+LINEAR_WEBHOOK_SECRET=
+# STRIPE_WEBHOOK_SECRET=whsec_...
+
+# ── Optional ─────────────────────────────────────────────────────────────────
+# Redis URL for BullMQ queues (default: redis://localhost:6379)
 # REDIS_URL=redis://localhost:6379
 
-# Server port (defaults to 3100 from Paperclip config)
+# Server port (default: 3100 from Paperclip config)
 # PORT=3100

--- a/services/execution-service/.env.example
+++ b/services/execution-service/.env.example
@@ -1,43 +1,88 @@
-# Execution Service — required environment variables
+# ── Execution Service ─────────────────────────────────────────────────────────
 # All vars listed as "Required" MUST be set before starting the service.
 
-# Required
+# ── Required ─────────────────────────────────────────────────────────────────
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/clawdb
 REDIS_URL=redis://localhost:6379
-AUTH_SECRET=your-secret-here  # Must match UI's AUTH_SECRET
+AUTH_SECRET=your-secret-here                   # Must match UI's AUTH_SECRET
+BOT_JWT_SECRET=your-bot-jwt-secret             # Must match tool-gateway
 
-# Optional (defaults shown)
-PORT=3001
-LOG_LEVEL=info
+# ── Optional (defaults shown) ────────────────────────────────────────────────
+# PORT=3001
+# LOG_LEVEL=info
+# NODE_ENV=development
 CORS_ORIGIN=http://localhost:5173
 
-# GCP — required in production (NODE_ENV=production)
+# ── GCP — required in production ─────────────────────────────────────────────
 GCP_PROJECT_ID=claw-local
 GCP_ZONE=us-central1-a
 GCP_NETWORK=default
 GCP_SUBNET=default
 GCP_BOT_SERVICE_ACCOUNT=bot-vm@your-project.iam.gserviceaccount.com
 LLM_API_KEY_SECRET_NAME=llm-api-key
+# LLM_PROVIDER=anthropic
 
-# Bot auth
-BOT_JWT_SECRET=your-bot-jwt-secret
+# Tool Gateway URLs
+TOOL_GATEWAY_VPC_URL=http://10.0.0.3:3002      # Injected into bot VMs as HTTP_PROXY
+TOOL_GATEWAY_URL=http://localhost:3002          # Used by execution-service itself
 
-# Tool Gateway URL (injected into bot VMs as HTTP_PROXY)
-TOOL_GATEWAY_VPC_URL=http://10.0.0.3:3002
+# ── Pub/Sub topics (optional — defaults to standard names) ───────────────────
+# BOT_LIFECYCLE_TOPIC=bot-lifecycle
+# TASK_LIFECYCLE_TOPIC=task-lifecycle
+# EXECUTION_LIFECYCLE_TOPIC=execution-lifecycle
+# GUARDRAIL_EVENTS_TOPIC=guardrail-events
+# BILLING_EVENTS_TOPIC=billing-events
+# SOUL_LIFECYCLE_TOPIC=soul-lifecycle
+# RING_LEADER_EVENTS_TOPIC=ring-leader-events
 
-# Pub/Sub topics (optional — defaults to standard names)
-BOT_LIFECYCLE_TOPIC=bot-lifecycle
-TASK_LIFECYCLE_TOPIC=task-lifecycle
-GUARDRAIL_EVENTS_TOPIC=guardrail-events
+# Pub/Sub subscriptions
+# BOT_LIFECYCLE_SUBSCRIPTION=bot-lifecycle-sub
+# BILLING_SUBSCRIPTION=billing-sub
 
-# Timeouts (milliseconds)
-BOT_WAIT_TIMEOUT_MS=600000
-TASK_EXECUTION_TIMEOUT_MS=1800000
+# Pub/Sub emulator (local dev only)
+# PUBSUB_EMULATOR_HOST=localhost:8085
 
-# Billing rates (cents per unit)
+# ── Timeouts (milliseconds) ─────────────────────────────────────────────────
+# BOT_WAIT_TIMEOUT_MS=600000           # 10 min — max wait for bot ready
+# TASK_EXECUTION_TIMEOUT_MS=1800000    # 30 min — max single task duration
+# SPAWN_CHECK_INTERVAL_MS=5000
+# SPAWN_TIMEOUT_MS=300000
+# IDLE_CHECK_INTERVAL_MS=60000
+# IDLE_TIMEOUT_MS=300000
+# WATCHDOG_INTERVAL_MS=60000
+
+# ── Billing / Stripe ────────────────────────────────────────────────────────
+# STRIPE_SECRET_KEY=sk_test_...
+# STRIPE_WEBHOOK_SECRET=whsec_...
+# STRIPE_BOT_HOURS_PRODUCT_ID=
+# STRIPE_LLM_INPUT_PRODUCT_ID=
+# STRIPE_LLM_OUTPUT_PRODUCT_ID=
+# STRIPE_TOOL_INVOCATIONS_PRODUCT_ID=
 LLM_INPUT_RATE_CENTS_PER_M=300
 LLM_OUTPUT_RATE_CENTS_PER_M=1500
 BOT_HOURLY_RATE_CENTS=50
 
-# Optional: bypass auth for CLI testing (not for production)
+# ── Evolution engine tuning ──────────────────────────────────────────────────
+# SCORE_WEIGHT_SUCCESS=0.4
+# SCORE_WEIGHT_EFFICIENCY=0.25
+# SCORE_WEIGHT_COST=0.15
+# SCORE_WEIGHT_STABILITY=0.2
+# DNA_ELITE_THRESHOLD=0.85
+# DNA_ABOVE_AVERAGE_PCT=65
+# DNA_ERROR_RATE_CEILING=0.15
+# TIER_HIGH_THRESHOLD=0.75
+# TIER_MEDIUM_THRESHOLD=0.45
+
+# ── Council / planner LLM models ────────────────────────────────────────────
+# COORDINATION_SCORER_MODEL=
+# SOUL_SELECTION_SCORER_MODEL=
+# PLANNER_MODEL=
+# SYNTHESIS_MODEL=
+# COORDINATION_POLL_INTERVAL_MS=30000
+
+# ── Guardrail tuning ────────────────────────────────────────────────────────
+# GUARDRAIL_DENY_TTL_SECONDS=300
+# LOOP_DETECTION_WINDOW=5
+
+# ── Internal access (not for production) ─────────────────────────────────────
 # INTERNAL_API_KEY=

--- a/services/tool-gateway/.env.example
+++ b/services/tool-gateway/.env.example
@@ -1,16 +1,32 @@
-# Tool Gateway — HTTP forward proxy for bot VM egress
-# Required
+# ── Tool Gateway ──────────────────────────────────────────────────────────────
+# HTTP forward proxy + Tool Nexus for bot VM egress
+
+# ── Required ─────────────────────────────────────────────────────────────────
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/clawdb
 REDIS_URL=redis://localhost:6379
 
-# Optional
-PORT=3002
-LOG_LEVEL=info
+# ── Optional (defaults shown) ────────────────────────────────────────────────
+# PORT=3002
+# LOG_LEVEL=info
+# NODE_ENV=development
 
-# Comma-separated domain allowlist for bot egress.
-# Empty = allow all (development only; restrict in production).
+# Comma-separated domain allowlist for bot egress
+# Empty = allow all (development only; restrict in production)
 # Example: api.anthropic.com,api.openai.com,generativelanguage.googleapis.com
 PROXY_DOMAIN_ALLOWLIST=
 
 # JWT secret for bot authentication (must match execution-service BOT_JWT_SECRET)
 BOT_JWT_SECRET=
+
+# GCP project ID for Pub/Sub event publishing
+GCP_PROJECT_ID=claw-local
+
+# Pub/Sub emulator (local dev only)
+# PUBSUB_EMULATOR_HOST=localhost:8085
+
+# Pub/Sub topics
+# BILLING_EVENTS_TOPIC=billing-events
+
+# Billing rates (used for metering tool invocations)
+LLM_INPUT_RATE_CENTS_PER_M=300
+LLM_OUTPUT_RATE_CENTS_PER_M=1500

--- a/services/ui/.env.example
+++ b/services/ui/.env.example
@@ -1,8 +1,11 @@
-# Auth.js Google OAuth
-# Generate AUTH_SECRET with: openssl rand -base64 32
+# ── SvelteKit UI ──────────────────────────────────────────────────────────────
+
+# ── Required ─────────────────────────────────────────────────────────────────
+# Auth.js secret — must match execution-service's AUTH_SECRET
+# Generate with: openssl rand -base64 32
 AUTH_SECRET=your-secret-here
 
-# Google OAuth credentials
+# Google OAuth credentials for user login
 # Set up at: Google Cloud Console -> APIs & Services -> Credentials
 # Authorized redirect URI for local dev: http://localhost:5173/auth/callback/google
 AUTH_GOOGLE_ID=your-google-client-id
@@ -11,6 +14,6 @@ AUTH_GOOGLE_SECRET=your-google-client-secret
 # Required for non-Vercel environments (local dev)
 AUTH_TRUST_HOST=true
 
-# URL of execution-service for server-side calls (not the /api proxy)
-# Server actions run on Vercel and must call the service directly
-EXECUTION_SERVICE_URL=http://34.30.239.113:3001
+# URL of execution-service for server-side API proxy
+# In production, set to the Railway/GCP internal URL
+EXECUTION_SERVICE_URL=http://localhost:3001


### PR DESCRIPTION
## Summary
- Expanded root `.env.example` from 4 lines to 214 lines covering all 65+ environment variables used across the monorepo
- Updated service-specific `.env.example` files for `execution-service`, `tool-gateway`, `ui`, and `akasa-server` with full variable coverage
- Organized by logical section (infrastructure, GCP, Pub/Sub, timeouts, billing, evolution tuning, OAuth, etc.) with descriptions and defaults

## Test plan
- [ ] Verify a fresh clone can copy `.env.example` to `.env` and start all services with `docker compose`
- [ ] Confirm no env vars are missing by grepping `process.env` and cross-referencing

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)