### PR TITLE
feat(marketplace): add reviews and ratings for Akashic Library

### DIFF
--- a/packages/db/migrations/0021_marketplace_reviews.sql
+++ b/packages/db/migrations/0021_marketplace_reviews.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS "marketplace_reviews" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" text NOT NULL,
+  "target_id" uuid NOT NULL,
+  "target_type" text NOT NULL,
+  "rating" integer NOT NULL,
+  "review_text" text,
+  "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "rating_range" CHECK ("rating" >= 1 AND "rating" <= 5),
+  CONSTRAINT "target_type_valid" CHECK ("target_type" IN ('soul', 'skill'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "marketplace_reviews_user_target_uniq" ON "marketplace_reviews" ("user_id", "target_id");
+CREATE INDEX IF NOT EXISTS "marketplace_reviews_target_idx" ON "marketplace_reviews" ("target_id", "target_type");

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -25,3 +25,4 @@ export * from "./user-preferences";
 export * from "./api-keys";
 export * from "./learned-skills";
 export * from "./tool-registry";
+export * from "./marketplace-reviews";

--- a/packages/db/src/schema/marketplace-reviews.ts
+++ b/packages/db/src/schema/marketplace-reviews.ts
@@ -1,0 +1,33 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  integer,
+  timestamp,
+  index,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
+
+export type ReviewTargetType = 'soul' | 'skill';
+export const REVIEW_TARGET_TYPES = ['soul', 'skill'] as const;
+
+export const marketplaceReviews = pgTable(
+  'marketplace_reviews',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: text('user_id').notNull(),
+    targetId: uuid('target_id').notNull(),
+    targetType: text('target_type').notNull().$type<ReviewTargetType>(),
+    rating: integer('rating').notNull(),
+    reviewText: text('review_text'),
+    createdAt: timestamp('created_at', { withTimezone: true, precision: 3 }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, precision: 3 }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('marketplace_reviews_user_target_uniq').on(t.userId, t.targetId),
+    index('marketplace_reviews_target_idx').on(t.targetId, t.targetType),
+  ],
+);
+
+export type MarketplaceReview = typeof marketplaceReviews.$inferSelect;
+export type NewMarketplaceReview = typeof marketplaceReviews.$inferInsert;

--- a/services/akasa-server/src/routes/index.ts
+++ b/services/akasa-server/src/routes/index.ts
@@ -17,6 +17,7 @@ import { settingsRouter } from './settings.js';
 import { skillsRouter } from './skills.js';
 import { agentSkillsRouter } from './agent-skills.js';
 import { toolRegistryRouter } from './tool-registry.js';
+import { reviewsRouter } from './reviews.js';
 
 const akasaRouter = Router();
 
@@ -76,5 +77,8 @@ akasaRouter.use('/akasa/agents', agentSkillsRouter());
 
 // OpenAPI/Swagger import and tool registry management
 akasaRouter.use('/akasa/tool-registry', toolRegistryRouter());
+
+// Marketplace reviews and ratings (Akashic Library + Skill Bazaar)
+akasaRouter.use('/akasa/reviews', reviewsRouter());
 
 export { akasaRouter };

--- a/services/akasa-server/src/routes/reviews.ts
+++ b/services/akasa-server/src/routes/reviews.ts
@@ -1,0 +1,191 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { db, marketplaceReviews, type ReviewTargetType, REVIEW_TARGET_TYPES } from '@claw/db';
+import { eq, and, sql } from 'drizzle-orm';
+
+interface SubmitReviewBody {
+  userId: string;
+  targetId: string;
+  targetType: ReviewTargetType;
+  rating: number;
+  reviewText?: string;
+}
+
+interface ReviewsQuery {
+  targetId?: string;
+  targetType?: string;
+}
+
+interface SummaryQuery {
+  targetId?: string;
+}
+
+export function reviewsRouter(): Router {
+  const router = Router();
+
+  // POST / — submit or update a review
+  router.post('/', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const body = req.body as SubmitReviewBody;
+
+      if (!body.userId || typeof body.userId !== 'string') {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      if (!body.targetId || typeof body.targetId !== 'string') {
+        res.status(400).json({ error: 'targetId is required' });
+        return;
+      }
+
+      if (!body.targetType || !REVIEW_TARGET_TYPES.includes(body.targetType)) {
+        res.status(400).json({ error: 'targetType must be "soul" or "skill"' });
+        return;
+      }
+
+      if (typeof body.rating !== 'number' || body.rating < 1 || body.rating > 5 || !Number.isInteger(body.rating)) {
+        res.status(400).json({ error: 'rating must be an integer between 1 and 5' });
+        return;
+      }
+
+      // Upsert: one review per user per target
+      const existing = await db
+        .select({ id: marketplaceReviews.id })
+        .from(marketplaceReviews)
+        .where(
+          and(
+            eq(marketplaceReviews.userId, body.userId),
+            eq(marketplaceReviews.targetId, body.targetId),
+          ),
+        )
+        .limit(1);
+
+      if (existing[0]) {
+        const updated = await db
+          .update(marketplaceReviews)
+          .set({
+            rating: body.rating,
+            reviewText: body.reviewText ?? null,
+            updatedAt: new Date(),
+          })
+          .where(eq(marketplaceReviews.id, existing[0].id))
+          .returning();
+
+        res.json(updated[0]);
+        return;
+      }
+
+      const inserted = await db
+        .insert(marketplaceReviews)
+        .values({
+          userId: body.userId,
+          targetId: body.targetId,
+          targetType: body.targetType,
+          rating: body.rating,
+          reviewText: body.reviewText ?? null,
+        })
+        .returning();
+
+      res.status(201).json(inserted[0]);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // GET / — list reviews for a target
+  router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const query = req.query as ReviewsQuery;
+
+      if (!query.targetId) {
+        res.status(400).json({ error: 'targetId query parameter is required' });
+        return;
+      }
+
+      const conditions = [eq(marketplaceReviews.targetId, query.targetId)];
+
+      if (query.targetType && REVIEW_TARGET_TYPES.includes(query.targetType as ReviewTargetType)) {
+        conditions.push(eq(marketplaceReviews.targetType, query.targetType as ReviewTargetType));
+      }
+
+      const reviews = await db
+        .select()
+        .from(marketplaceReviews)
+        .where(and(...conditions))
+        .orderBy(marketplaceReviews.createdAt);
+
+      res.json(reviews);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // GET /summary — average rating + count for a target
+  router.get('/summary', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const query = req.query as SummaryQuery;
+
+      if (!query.targetId) {
+        res.status(400).json({ error: 'targetId query parameter is required' });
+        return;
+      }
+
+      const result = await db
+        .select({
+          avgRating: sql<string>`COALESCE(AVG(${marketplaceReviews.rating}), 0)`,
+          count: sql<number>`COUNT(*)`,
+        })
+        .from(marketplaceReviews)
+        .where(eq(marketplaceReviews.targetId, query.targetId));
+
+      const row = result[0];
+      res.json({
+        targetId: query.targetId,
+        avgRating: row ? parseFloat(row.avgRating) : 0,
+        count: row ? Number(row.count) : 0,
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // DELETE /:id — delete own review
+  router.delete('/:id', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = req.params;
+
+      if (!id) {
+        res.status(400).json({ error: 'Review ID is required' });
+        return;
+      }
+
+      const rows = await db
+        .select()
+        .from(marketplaceReviews)
+        .where(eq(marketplaceReviews.id, id))
+        .limit(1);
+
+      const review = rows[0];
+      if (!review) {
+        res.status(404).json({ error: 'Review not found' });
+        return;
+      }
+
+      // userId check: the caller must pass their userId as a query param
+      const userId = req.query['userId'] as string | undefined;
+      if (!userId || userId !== review.userId) {
+        res.status(403).json({ error: 'You can only delete your own reviews' });
+        return;
+      }
+
+      await db
+        .delete(marketplaceReviews)
+        .where(eq(marketplaceReviews.id, id));
+
+      res.json({ deleted: true });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/services/ui/src/lib/api.ts
+++ b/services/ui/src/lib/api.ts
@@ -646,3 +646,60 @@ export async function unequipSkill(
     method: 'DELETE',
   });
 }
+
+// ── Marketplace Reviews ─────────────────────────────────────────
+
+export interface MarketplaceReview {
+  id: string;
+  userId: string;
+  targetId: string;
+  targetType: 'soul' | 'skill';
+  rating: number;
+  reviewText: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ReviewSummary {
+  targetId: string;
+  avgRating: number;
+  count: number;
+}
+
+export interface SubmitReviewInput {
+  userId: string;
+  targetId: string;
+  targetType: 'soul' | 'skill';
+  rating: number;
+  reviewText?: string;
+}
+
+export async function submitReview(input: SubmitReviewInput): Promise<MarketplaceReview> {
+  return apiFetch(`${BASE}/akasa/reviews`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+}
+
+export async function getReviews(
+  targetId: string,
+  targetType?: 'soul' | 'skill',
+): Promise<MarketplaceReview[]> {
+  const query = new URLSearchParams({ targetId });
+  if (targetType) query.set('targetType', targetType);
+  return apiFetch(`${BASE}/akasa/reviews?${query.toString()}`);
+}
+
+export async function getReviewSummary(targetId: string): Promise<ReviewSummary> {
+  return apiFetch(`${BASE}/akasa/reviews/summary?targetId=${targetId}`);
+}
+
+export async function deleteReview(
+  reviewId: string,
+  userId: string,
+): Promise<{ deleted: boolean }> {
+  return apiFetch(`${BASE}/akasa/reviews/${reviewId}?userId=${encodeURIComponent(userId)}`, {
+    method: 'DELETE',
+  });
+}

--- a/services/ui/src/lib/components/StarRating.svelte
+++ b/services/ui/src/lib/components/StarRating.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+  interface Props {
+    rating?: number;
+    maxStars?: number;
+    interactive?: boolean;
+    size?: 'sm' | 'md' | 'lg';
+    onrate?: (rating: number) => void;
+  }
+
+  let {
+    rating = 0,
+    maxStars = 5,
+    interactive = false,
+    size = 'md',
+    onrate,
+  }: Props = $props();
+
+  let hoveredStar = $state(0);
+
+  function handleClick(star: number) {
+    if (!interactive) return;
+    onrate?.(star);
+  }
+
+  function handleMouseEnter(star: number) {
+    if (!interactive) return;
+    hoveredStar = star;
+  }
+
+  function handleMouseLeave() {
+    if (!interactive) return;
+    hoveredStar = 0;
+  }
+
+  const displayRating = $derived(hoveredStar > 0 ? hoveredStar : rating);
+</script>
+
+<div
+  class="star-rating star-rating--{size}"
+  class:star-rating--interactive={interactive}
+  role={interactive ? 'radiogroup' : 'img'}
+  aria-label={interactive ? 'Rate this item' : `Rating: ${rating} out of ${maxStars}`}
+  onmouseleave={handleMouseLeave}
+>
+  {#each Array(maxStars) as _, i}
+    {@const star = i + 1}
+    {@const filled = star <= displayRating}
+    {#if interactive}
+      <button
+        type="button"
+        class="star"
+        class:star--filled={filled}
+        aria-label="{star} star{star > 1 ? 's' : ''}"
+        onclick={() => handleClick(star)}
+        onmouseenter={() => handleMouseEnter(star)}
+      >
+        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"
+            fill={filled ? 'currentColor' : 'none'}
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </button>
+    {:else}
+      <span class="star" class:star--filled={filled}>
+        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"
+            fill={filled ? 'currentColor' : 'none'}
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </span>
+    {/if}
+  {/each}
+</div>
+
+<style>
+  .star-rating {
+    display: inline-flex;
+    gap: 2px;
+    align-items: center;
+  }
+
+  .star-rating--interactive {
+    cursor: pointer;
+  }
+
+  .star {
+    display: inline-flex;
+    color: var(--bo-border);
+    transition: color 0.15s;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    line-height: 1;
+  }
+
+  .star--filled {
+    color: var(--bo-amber);
+  }
+
+  .star-rating--interactive .star:hover {
+    color: var(--bo-amber);
+  }
+
+  .star-rating--interactive .star {
+    cursor: pointer;
+  }
+
+  .star-rating--sm .star svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  .star-rating--md .star svg {
+    width: 18px;
+    height: 18px;
+  }
+
+  .star-rating--lg .star svg {
+    width: 24px;
+    height: 24px;
+  }
+</style>

--- a/services/ui/src/routes/(app)/akashic/+page.svelte
+++ b/services/ui/src/routes/(app)/akashic/+page.svelte
@@ -1,5 +1,23 @@
 <script lang="ts">
   import type { PageData } from './$types';
+  import StarRating from '$lib/components/StarRating.svelte';
+
+  interface ReviewSummary {
+    targetId: string;
+    avgRating: number;
+    count: number;
+  }
+
+  interface Review {
+    id: string;
+    userId: string;
+    targetId: string;
+    targetType: string;
+    rating: number;
+    reviewText: string | null;
+    createdAt: string;
+    updatedAt: string;
+  }
 
   let { data }: { data: PageData } = $props();
 
@@ -8,6 +26,15 @@
   let filterTaskCategory = $state(data.filters.taskCategory ?? '');
   let filterMinScore = $state(data.filters.minScore ?? '');
   let filterSortBy = $state(data.filters.sortBy ?? 'score');
+
+  // Reviews state
+  let reviewSummaries = $state<Record<string, ReviewSummary>>({});
+  let selectedReviews = $state<Review[]>([]);
+  let loadingReviews = $state(false);
+  let reviewFormRating = $state(0);
+  let reviewFormText = $state('');
+  let submittingReview = $state(false);
+  let reviewError = $state('');
 
   function buildUrl(page: number): string {
     const params = new URLSearchParams();
@@ -33,6 +60,116 @@
       acquiringId = null;
     }
   }
+
+  async function loadReviewSummary(targetId: string) {
+    try {
+      const res = await fetch(`/api/akasa/reviews/summary?targetId=${targetId}`);
+      if (res.ok) {
+        const summary: ReviewSummary = await res.json();
+        reviewSummaries = { ...reviewSummaries, [targetId]: summary };
+      }
+    } catch {
+      // Non-critical — fail silently
+    }
+  }
+
+  async function loadReviews(targetId: string) {
+    loadingReviews = true;
+    selectedReviews = [];
+    try {
+      const res = await fetch(`/api/akasa/reviews?targetId=${targetId}&targetType=soul`);
+      if (res.ok) {
+        selectedReviews = await res.json();
+      }
+    } catch {
+      selectedReviews = [];
+    } finally {
+      loadingReviews = false;
+    }
+  }
+
+  async function handleSelectEntry(entry: Record<string, unknown>) {
+    if (selectedEntry?.id === entry.id) {
+      selectedEntry = null;
+      selectedReviews = [];
+      return;
+    }
+    selectedEntry = entry;
+    reviewFormRating = 0;
+    reviewFormText = '';
+    reviewError = '';
+    await Promise.allSettled([
+      loadReviewSummary(entry.id as string),
+      loadReviews(entry.id as string),
+    ]);
+  }
+
+  async function handleSubmitReview() {
+    if (!selectedEntry || reviewFormRating < 1) {
+      reviewError = 'Please select a rating';
+      return;
+    }
+
+    submittingReview = true;
+    reviewError = '';
+    try {
+      const res = await fetch('/api/akasa/reviews', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          userId: data.session?.user?.email ?? 'anonymous',
+          targetId: selectedEntry.id,
+          targetType: 'soul',
+          rating: reviewFormRating,
+          reviewText: reviewFormText || undefined,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: 'Failed to submit review' }));
+        reviewError = body.error ?? 'Failed to submit review';
+        return;
+      }
+      // Refresh reviews and summary
+      const targetId = selectedEntry.id as string;
+      reviewFormRating = 0;
+      reviewFormText = '';
+      await Promise.allSettled([
+        loadReviewSummary(targetId),
+        loadReviews(targetId),
+      ]);
+    } catch {
+      reviewError = 'Network error — please try again';
+    } finally {
+      submittingReview = false;
+    }
+  }
+
+  async function handleDeleteReview(reviewId: string) {
+    const userId = data.session?.user?.email ?? 'anonymous';
+    try {
+      const res = await fetch(`/api/akasa/reviews/${reviewId}?userId=${encodeURIComponent(userId)}`, {
+        method: 'DELETE',
+      });
+      if (res.ok && selectedEntry) {
+        const targetId = selectedEntry.id as string;
+        await Promise.allSettled([
+          loadReviewSummary(targetId),
+          loadReviews(targetId),
+        ]);
+      }
+    } catch {
+      // Non-critical
+    }
+  }
+
+  // Load summaries for visible entries on mount
+  $effect(() => {
+    for (const entry of data.browse.entries) {
+      if (!reviewSummaries[entry.id]) {
+        loadReviewSummary(entry.id);
+      }
+    }
+  });
 </script>
 
 <div class="akashic-page">
@@ -91,7 +228,7 @@
           {#each data.browse.entries as entry (entry.id)}
             <button
               class="soul-card"
-              onclick={() => selectedEntry = selectedEntry?.id === entry.id ? null : entry}
+              onclick={() => handleSelectEntry(entry)}
               aria-expanded={selectedEntry?.id === entry.id}
             >
               <div class="soul-card-header">
@@ -107,12 +244,77 @@
                 <span class="meta-chip acquired">{entry.acquiredCount} acquired</span>
               </div>
 
+              {#if reviewSummaries[entry.id] && reviewSummaries[entry.id].count > 0}
+                <div class="soul-rating-summary">
+                  <StarRating rating={Math.round(reviewSummaries[entry.id].avgRating)} size="sm" />
+                  <span class="rating-count">({reviewSummaries[entry.id].count})</span>
+                </div>
+              {/if}
+
               {#if entry.taskCategory}
                 <span class="soul-category">{entry.taskCategory}</span>
               {/if}
             </button>
           {/each}
         </div>
+
+        {#if selectedEntry}
+          <section class="reviews-panel">
+            <h2 class="reviews-heading">Reviews for {selectedEntry.title ?? 'Untitled Soul'}</h2>
+
+            {#if reviewSummaries[selectedEntry.id as string]}
+              {@const summary = reviewSummaries[selectedEntry.id as string]}
+              <div class="reviews-summary-bar">
+                <StarRating rating={Math.round(summary.avgRating)} size="md" />
+                <span class="reviews-avg">{summary.avgRating.toFixed(1)}</span>
+                <span class="reviews-count">{summary.count} review{summary.count !== 1 ? 's' : ''}</span>
+              </div>
+            {/if}
+
+            <form class="review-form" onsubmit={(e) => { e.preventDefault(); handleSubmitReview(); }}>
+              <div class="review-form-rating">
+                <span class="review-form-label">Your rating</span>
+                <StarRating rating={reviewFormRating} interactive={true} size="lg" onrate={(r) => { reviewFormRating = r; }} />
+              </div>
+              <textarea
+                class="review-textarea"
+                placeholder="Write a review (optional)"
+                rows={3}
+                bind:value={reviewFormText}
+              ></textarea>
+              {#if reviewError}
+                <p class="review-error">{reviewError}</p>
+              {/if}
+              <button type="submit" class="review-submit-btn" disabled={submittingReview || reviewFormRating < 1}>
+                {submittingReview ? 'Submitting...' : 'Submit Review'}
+              </button>
+            </form>
+
+            <div class="reviews-list">
+              {#if loadingReviews}
+                <p class="reviews-loading">Loading reviews...</p>
+              {:else if selectedReviews.length === 0}
+                <p class="reviews-empty">No reviews yet. Be the first to review this soul.</p>
+              {:else}
+                {#each selectedReviews as review (review.id)}
+                  <div class="review-item">
+                    <div class="review-item-header">
+                      <StarRating rating={review.rating} size="sm" />
+                      <span class="review-author">{review.userId}</span>
+                      <span class="review-date">{new Date(review.createdAt).toLocaleDateString()}</span>
+                      {#if review.userId === (data.session?.user?.email ?? 'anonymous')}
+                        <button class="review-delete-btn" onclick={() => handleDeleteReview(review.id)}>Delete</button>
+                      {/if}
+                    </div>
+                    {#if review.reviewText}
+                      <p class="review-text">{review.reviewText}</p>
+                    {/if}
+                  </div>
+                {/each}
+              {/if}
+            </div>
+          </section>
+        {/if}
 
         <nav class="pagination" aria-label="Browse pagination">
           {#if data.browse.page > 1}
@@ -375,5 +577,194 @@
     font-family: var(--font-body);
     font-size: 12px;
     color: var(--bo-muted);
+  }
+
+  /* ── Soul rating summary (on card) ─────────── */
+  .soul-rating-summary {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    margin-top: var(--space-xs);
+  }
+
+  .rating-count {
+    font-family: var(--font-body);
+    font-size: 11px;
+    color: var(--bo-muted);
+  }
+
+  /* ── Reviews panel ─────────────────────────── */
+  .reviews-panel {
+    background: var(--bo-card);
+    border: 1px solid var(--bo-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+  }
+
+  .reviews-heading {
+    font-family: var(--font-display);
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--bo-text);
+    margin: 0;
+  }
+
+  .reviews-summary-bar {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+  }
+
+  .reviews-avg {
+    font-family: var(--font-mono);
+    font-size: 16px;
+    color: var(--bo-amber);
+    font-weight: 600;
+  }
+
+  .reviews-count {
+    font-family: var(--font-body);
+    font-size: 13px;
+    color: var(--bo-muted);
+  }
+
+  /* ── Review form ───────────────────────────── */
+  .review-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+    border-top: 1px solid var(--bo-border);
+    padding-top: var(--space-lg);
+  }
+
+  .review-form-rating {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+  }
+
+  .review-form-label {
+    font-family: var(--font-label);
+    font-size: 5px;
+    letter-spacing: 0.10em;
+    color: var(--bo-caption);
+  }
+
+  .review-textarea {
+    background: var(--bo-bg);
+    border: 1px solid var(--bo-border);
+    border-radius: var(--radius-sm);
+    color: var(--bo-text);
+    font-family: var(--font-body);
+    font-size: 13px;
+    padding: var(--space-sm) var(--space-md);
+    resize: vertical;
+    outline: none;
+    transition: border-color 0.15s;
+  }
+
+  .review-textarea:focus {
+    border-color: var(--bo-vb);
+  }
+
+  .review-error {
+    font-family: var(--font-body);
+    font-size: 12px;
+    color: #e74c3c;
+    margin: 0;
+  }
+
+  .review-submit-btn {
+    align-self: flex-start;
+    background: var(--bo-violet);
+    color: white;
+    font-family: var(--font-label);
+    font-size: 6px;
+    letter-spacing: 0.10em;
+    padding: var(--space-sm) var(--space-lg);
+    border: none;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background 0.15s, opacity 0.15s;
+  }
+
+  .review-submit-btn:hover:not(:disabled) {
+    background: var(--bo-vb);
+  }
+
+  .review-submit-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* ── Reviews list ──────────────────────────── */
+  .reviews-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .reviews-loading,
+  .reviews-empty {
+    font-family: var(--font-body);
+    font-size: 13px;
+    color: var(--bo-faint);
+    margin: 0;
+  }
+
+  .review-item {
+    border-top: 1px solid var(--bo-border);
+    padding-top: var(--space-md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+
+  .review-item-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    flex-wrap: wrap;
+  }
+
+  .review-author {
+    font-family: var(--font-body);
+    font-size: 12px;
+    color: var(--bo-text);
+    font-weight: 500;
+  }
+
+  .review-date {
+    font-family: var(--font-body);
+    font-size: 11px;
+    color: var(--bo-faint);
+  }
+
+  .review-delete-btn {
+    background: none;
+    border: none;
+    font-family: var(--font-label);
+    font-size: 5px;
+    letter-spacing: 0.08em;
+    color: #e74c3c;
+    cursor: pointer;
+    padding: 2px 4px;
+    margin-left: auto;
+    transition: opacity 0.15s;
+  }
+
+  .review-delete-btn:hover {
+    opacity: 0.7;
+  }
+
+  .review-text {
+    font-family: var(--font-body);
+    font-size: 13px;
+    color: var(--bo-muted);
+    margin: 0;
+    line-height: 1.6;
   }
 </style>


### PR DESCRIPTION
## Summary
- Add `marketplace_reviews` DB table with unique constraint per (userId, targetId), rating range check (1-5), and target type validation (soul/skill)
- Add backend Express routes: `POST /akasa/reviews` (submit/upsert), `GET /akasa/reviews` (list by target), `GET /akasa/reviews/summary` (avg + count), `DELETE /akasa/reviews/:id` (own review only)
- Add reusable `StarRating.svelte` component with interactive and display modes, three sizes (sm/md/lg)
- Integrate reviews panel into Akashic Library browse page: inline star ratings on soul cards, expandable review form and review list per selected soul
- Add typed API client functions in `lib/api.ts` for reviews CRUD

## Test plan
- [ ] Apply migration `0021_marketplace_reviews.sql` and verify table creation
- [ ] POST a review via `/akasa/reviews` and confirm 201 response with correct data
- [ ] POST again for same user+target and confirm upsert (200 response, updated rating)
- [ ] GET reviews by targetId and verify list returns
- [ ] GET summary and verify avgRating and count
- [ ] DELETE own review and verify 200; attempt DELETE of another user's review and verify 403
- [ ] Browse Akashic Library page and verify star ratings appear on cards with reviews
- [ ] Click a soul card, verify reviews panel expands with form and existing reviews
- [ ] Submit a review via the form and verify it appears in the list
- [ ] Delete own review via the delete button

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)