### PR TITLE
test: add missing unit tests for core services

### DIFF
--- a/services/akasa-server/src/__tests__/fleet-event-bus.test.ts
+++ b/services/akasa-server/src/__tests__/fleet-event-bus.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fleetEventBus } from '../services/fleet-event-bus.js';
+
+describe('fleet-event-bus', () => {
+  it('is a singleton (same instance on every import)', async () => {
+    const { fleetEventBus: bus2 } = await import('../services/fleet-event-bus.js');
+    expect(fleetEventBus).toBe(bus2);
+  });
+
+  it('emitFleetEvent delivers event to onFleetEvent listeners', () => {
+    const handler = vi.fn();
+    const unsub = fleetEventBus.onFleetEvent(handler);
+
+    const event = { type: 'bot_spawned', timestamp: new Date().toISOString() } as any;
+    fleetEventBus.emitFleetEvent(event);
+
+    expect(handler).toHaveBeenCalledWith(event);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    unsub();
+  });
+
+  it('onFleetEvent returns an unsubscribe function', () => {
+    const handler = vi.fn();
+    const unsub = fleetEventBus.onFleetEvent(handler);
+
+    fleetEventBus.emitFleetEvent({ type: 'first' } as any);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    unsub();
+
+    fleetEventBus.emitFleetEvent({ type: 'second' } as any);
+    expect(handler).toHaveBeenCalledTimes(1); // still 1 after unsub
+  });
+
+  it('supports multiple listeners', () => {
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+    const unsub1 = fleetEventBus.onFleetEvent(handler1);
+    const unsub2 = fleetEventBus.onFleetEvent(handler2);
+
+    fleetEventBus.emitFleetEvent({ type: 'test' } as any);
+
+    expect(handler1).toHaveBeenCalledTimes(1);
+    expect(handler2).toHaveBeenCalledTimes(1);
+
+    unsub1();
+    unsub2();
+  });
+});

--- a/services/akasa-server/src/__tests__/god-layer-handler.test.ts
+++ b/services/akasa-server/src/__tests__/god-layer-handler.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockDb,
+  mockComputeClassTransition,
+  mockCaptureDna,
+  mockRecordNegativeSignal,
+  mockCheckAndRecordPioneer,
+  mockProcessSkillUnlearning,
+  mockProcessSkillLearningForExecution,
+} = vi.hoisted(() => ({
+  mockDb: { select: vi.fn(), update: vi.fn(), insert: vi.fn() },
+  mockComputeClassTransition: vi.fn(),
+  mockCaptureDna: vi.fn(),
+  mockRecordNegativeSignal: vi.fn(),
+  mockCheckAndRecordPioneer: vi.fn(),
+  mockProcessSkillUnlearning: vi.fn(),
+  mockProcessSkillLearningForExecution: vi.fn(),
+}));
+
+vi.mock('@claw/db', () => ({
+  db: mockDb,
+  councilVerdicts: { id: 'id' },
+  bots: { id: 'id' },
+  botSouls: { id: 'id' },
+  agentClasses: { botId: 'botId', updatedAt: 'updatedAt' },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: (...args: unknown[]) => ({ _type: 'eq', args }),
+  desc: (col: unknown) => ({ _type: 'desc', col }),
+}));
+
+vi.mock('../god-layer/class-machine.js', () => ({
+  computeClassTransition: (...args: unknown[]) => mockComputeClassTransition(...args),
+}));
+
+vi.mock('../god-layer/dna-writer.js', () => ({
+  captureDna: (...args: unknown[]) => mockCaptureDna(...args),
+}));
+
+vi.mock('../god-layer/negative-register.js', () => ({
+  recordNegativeSignal: (...args: unknown[]) => mockRecordNegativeSignal(...args),
+}));
+
+vi.mock('../god-layer/pioneer-tracker.js', () => ({
+  checkAndRecordPioneer: (...args: unknown[]) => mockCheckAndRecordPioneer(...args),
+}));
+
+vi.mock('../god-layer/skill-unlearning.js', () => ({
+  processSkillUnlearning: (...args: unknown[]) => mockProcessSkillUnlearning(...args),
+}));
+
+vi.mock('../services/skill-learning.js', () => ({
+  processSkillLearningForExecution: (...args: unknown[]) => mockProcessSkillLearningForExecution(...args),
+}));
+
+import { executeGodLayer } from '../god-layer/god-layer-handler.js';
+
+function makeSelectChain(data: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(data),
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(data),
+        }),
+      }),
+    }),
+  };
+}
+
+function makeUpdateChain() {
+  return {
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    }),
+  };
+}
+
+function makeInsertChain() {
+  return {
+    values: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const baseVerdict = {
+  id: 'verdict-1',
+  botId: 'bot-1',
+  executionId: 'exec-1',
+  soulId: 'soul-1',
+  verdictType: 'Promote',
+  status: 'confirmed',
+  godLayerProcessedAt: null,
+  verdictSummary: 'Strong performance',
+  weightedConfidenceScore: '0.85',
+  soulAnalystOutput: null,
+};
+
+const baseBot = {
+  id: 'bot-1',
+  executionId: 'exec-1',
+  soulId: 'soul-1',
+  compositeScore: '0.80',
+};
+
+const baseSoul = {
+  id: 'soul-1',
+  dimensions: { identityRole: 'test' },
+  taskCategory: 'research',
+};
+
+describe('god-layer-handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockComputeClassTransition.mockReturnValue({ transitioned: false, newClass: 'Novice' });
+    mockCaptureDna.mockResolvedValue(undefined);
+    mockRecordNegativeSignal.mockResolvedValue(undefined);
+    mockCheckAndRecordPioneer.mockResolvedValue(false);
+    mockProcessSkillUnlearning.mockResolvedValue({ unlearnedSkills: [] });
+    mockProcessSkillLearningForExecution.mockResolvedValue({ skillsCreated: 0, skillIds: [] });
+  });
+
+  it('returns processed=false with reason=verdict_not_found when verdict does not exist', async () => {
+    mockDb.select.mockReturnValue(makeSelectChain([]));
+
+    const result = await executeGodLayer('verdict-missing');
+
+    expect(result.processed).toBe(false);
+    expect(result.reason).toBe('verdict_not_found');
+  });
+
+  it('returns processed=false with reason=already_processed when godLayerProcessedAt is set', async () => {
+    mockDb.select.mockReturnValue(
+      makeSelectChain([{ ...baseVerdict, godLayerProcessedAt: new Date() }]),
+    );
+
+    const result = await executeGodLayer('verdict-1');
+
+    expect(result.processed).toBe(false);
+    expect(result.reason).toBe('already_processed');
+  });
+
+  it('calls computeClassTransition and inserts new class row on transition', async () => {
+    let selectCall = 0;
+    mockDb.select.mockImplementation(() => {
+      selectCall++;
+      if (selectCall === 1) return makeSelectChain([baseVerdict]); // verdict
+      if (selectCall === 2) return makeSelectChain([baseBot]); // bot
+      if (selectCall === 3) return makeSelectChain([baseSoul]); // soul
+      return makeSelectChain([{ currentClass: 'Novice' }]); // agent class
+    });
+
+    mockComputeClassTransition.mockReturnValue({ transitioned: true, newClass: 'Understudy' });
+    mockDb.insert.mockReturnValue(makeInsertChain());
+    mockDb.update.mockReturnValue(makeUpdateChain());
+
+    const result = await executeGodLayer('verdict-1');
+
+    expect(result.processed).toBe(true);
+    expect(mockComputeClassTransition).toHaveBeenCalled();
+    expect(mockDb.insert).toHaveBeenCalled();
+  });
+
+  it('captures DNA for Promote verdicts with sufficient composite score', async () => {
+    let selectCall = 0;
+    mockDb.select.mockImplementation(() => {
+      selectCall++;
+      if (selectCall === 1) return makeSelectChain([baseVerdict]); // Promote
+      if (selectCall === 2) return makeSelectChain([baseBot]); // compositeScore=0.80
+      if (selectCall === 3) return makeSelectChain([baseSoul]);
+      return makeSelectChain([]);
+    });
+
+    mockDb.update.mockReturnValue(makeUpdateChain());
+
+    const result = await executeGodLayer('verdict-1');
+
+    expect(result.processed).toBe(true);
+    expect(mockCaptureDna).toHaveBeenCalled();
+  });
+
+  it('records negative signal for Demote verdicts', async () => {
+    const demoteVerdict = { ...baseVerdict, verdictType: 'Demote' };
+
+    let selectCall = 0;
+    mockDb.select.mockImplementation(() => {
+      selectCall++;
+      if (selectCall === 1) return makeSelectChain([demoteVerdict]);
+      if (selectCall === 2) return makeSelectChain([baseBot]);
+      if (selectCall === 3) return makeSelectChain([baseSoul]);
+      return makeSelectChain([]);
+    });
+
+    mockDb.update.mockReturnValue(makeUpdateChain());
+
+    const result = await executeGodLayer('verdict-1');
+
+    expect(result.processed).toBe(true);
+    expect(mockRecordNegativeSignal).toHaveBeenCalled();
+    expect(mockCaptureDna).not.toHaveBeenCalled();
+  });
+
+  it('checks pioneer for Promote verdicts', async () => {
+    let selectCall = 0;
+    mockDb.select.mockImplementation(() => {
+      selectCall++;
+      if (selectCall === 1) return makeSelectChain([baseVerdict]);
+      if (selectCall === 2) return makeSelectChain([baseBot]);
+      if (selectCall === 3) return makeSelectChain([baseSoul]);
+      return makeSelectChain([]);
+    });
+
+    mockDb.update.mockReturnValue(makeUpdateChain());
+
+    await executeGodLayer('verdict-1');
+
+    expect(mockCheckAndRecordPioneer).toHaveBeenCalled();
+  });
+
+  it('does not check pioneer for non-Promote verdicts', async () => {
+    const maintainVerdict = { ...baseVerdict, verdictType: 'Maintain' };
+
+    let selectCall = 0;
+    mockDb.select.mockImplementation(() => {
+      selectCall++;
+      if (selectCall === 1) return makeSelectChain([maintainVerdict]);
+      if (selectCall === 2) return makeSelectChain([{ ...baseBot, compositeScore: '0.80' }]);
+      if (selectCall === 3) return makeSelectChain([baseSoul]);
+      return makeSelectChain([]);
+    });
+
+    mockDb.update.mockReturnValue(makeUpdateChain());
+
+    await executeGodLayer('verdict-1');
+
+    expect(mockCheckAndRecordPioneer).not.toHaveBeenCalled();
+  });
+
+  it('always processes skill unlearning regardless of verdict type', async () => {
+    let selectCall = 0;
+    mockDb.select.mockImplementation(() => {
+      selectCall++;
+      if (selectCall === 1) return makeSelectChain([baseVerdict]);
+      if (selectCall === 2) return makeSelectChain([baseBot]);
+      if (selectCall === 3) return makeSelectChain([baseSoul]);
+      return makeSelectChain([]);
+    });
+
+    mockDb.update.mockReturnValue(makeUpdateChain());
+
+    await executeGodLayer('verdict-1');
+
+    expect(mockProcessSkillUnlearning).toHaveBeenCalledWith(
+      'bot-1', 'exec-1', 'soul-1', 'Promote',
+    );
+  });
+
+  it('marks verdict as processed at the end', async () => {
+    let selectCall = 0;
+    mockDb.select.mockImplementation(() => {
+      selectCall++;
+      if (selectCall === 1) return makeSelectChain([baseVerdict]);
+      if (selectCall === 2) return makeSelectChain([baseBot]);
+      if (selectCall === 3) return makeSelectChain([baseSoul]);
+      return makeSelectChain([]);
+    });
+
+    mockDb.update.mockReturnValue(makeUpdateChain());
+
+    await executeGodLayer('verdict-1');
+
+    // The last update call should set godLayerProcessedAt
+    expect(mockDb.update).toHaveBeenCalled();
+  });
+});

--- a/services/akasa-server/src/__tests__/oauth-providers.test.ts
+++ b/services/akasa-server/src/__tests__/oauth-providers.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { OAUTH_PROVIDERS, getOAuthProvider } from '../services/oauth-providers.js';
+
+describe('oauth-providers', () => {
+  describe('OAUTH_PROVIDERS', () => {
+    it('contains all expected providers', () => {
+      const expectedProviders = [
+        'hubspot', 'slack', 'google-sheets', 'github', 'stripe',
+        'linear', 'notion', 'gmail', 'google-calendar',
+      ];
+      for (const provider of expectedProviders) {
+        expect(OAUTH_PROVIDERS).toHaveProperty(provider);
+      }
+    });
+
+    it('every provider has required fields', () => {
+      for (const [name, config] of Object.entries(OAUTH_PROVIDERS)) {
+        expect(config.authorizeUrl).toBeTruthy();
+        expect(config.tokenUrl).toBeTruthy();
+        expect(config.scopes.length).toBeGreaterThan(0);
+        expect(config.clientIdEnv).toBeTruthy();
+        expect(config.clientSecretEnv).toBeTruthy();
+      }
+    });
+
+    it('google-sheets has access_type=offline in extraAuthorizeParams', () => {
+      const gs = OAUTH_PROVIDERS['google-sheets']!;
+      expect(gs.extraAuthorizeParams?.access_type).toBe('offline');
+      expect(gs.extraAuthorizeParams?.prompt).toBe('consent');
+    });
+  });
+
+  describe('getOAuthProvider', () => {
+    it('returns config for a known provider', () => {
+      const config = getOAuthProvider('hubspot');
+      expect(config).toBeDefined();
+      expect(config!.authorizeUrl).toContain('hubspot.com');
+    });
+
+    it('returns undefined for unknown provider', () => {
+      expect(getOAuthProvider('unknown-provider')).toBeUndefined();
+    });
+  });
+});

--- a/services/akasa-server/src/__tests__/openapi-import.test.ts
+++ b/services/akasa-server/src/__tests__/openapi-import.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockDb, mockSwaggerParser } = vi.hoisted(() => ({
+  mockDb: {
+    insert: vi.fn(),
+    select: vi.fn(),
+    delete: vi.fn(),
+    update: vi.fn(),
+  },
+  mockSwaggerParser: {
+    dereference: vi.fn(),
+  },
+}));
+
+vi.mock('@claw/db', () => ({
+  db: mockDb,
+  toolRegistry: {
+    userId: 'userId',
+    specId: 'specId',
+    id: 'id',
+    isEnabled: 'isEnabled',
+    updatedAt: 'updatedAt',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: (...args: unknown[]) => ({ _type: 'eq', args }),
+  and: (...args: unknown[]) => ({ _type: 'and', args }),
+}));
+
+vi.mock('@apidevtools/swagger-parser', () => ({
+  default: mockSwaggerParser,
+}));
+
+import {
+  parseOpenApiSpec,
+  importEndpoints,
+  listToolRegistry,
+  deleteSpec,
+  toggleEndpoint,
+} from '../services/openapi-import.js';
+
+describe('openapi-import', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('parseOpenApiSpec', () => {
+    it('parses OpenAPI 3.x spec with servers array', async () => {
+      mockSwaggerParser.dereference.mockResolvedValue({
+        info: { title: 'Test API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com/v1' }],
+        paths: {
+          '/users': {
+            get: {
+              operationId: 'listUsers',
+              summary: 'List users',
+              tags: ['users'],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: { type: 'array', items: { type: 'object' } },
+                    },
+                  },
+                },
+              },
+            },
+            post: {
+              operationId: 'createUser',
+              summary: 'Create user',
+              tags: ['users'],
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: { type: 'object', properties: { name: { type: 'string' } } },
+                  },
+                },
+              },
+              responses: {
+                '201': {
+                  content: {
+                    'application/json': {
+                      schema: { type: 'object' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const result = await parseOpenApiSpec('https://api.example.com/spec.json');
+
+      expect(result.title).toBe('Test API');
+      expect(result.version).toBe('1.0.0');
+      expect(result.baseUrl).toBe('https://api.example.com/v1');
+      expect(result.endpoints).toHaveLength(2);
+
+      const getEndpoint = result.endpoints.find((e) => e.method === 'get');
+      expect(getEndpoint!.operationId).toBe('listUsers');
+      expect(getEndpoint!.path).toBe('/users');
+      expect(getEndpoint!.responseSchema).toBeDefined();
+
+      const postEndpoint = result.endpoints.find((e) => e.method === 'post');
+      expect(postEndpoint!.requestBody).toBeDefined();
+    });
+
+    it('parses Swagger 2.x spec with host and basePath', async () => {
+      mockSwaggerParser.dereference.mockResolvedValue({
+        info: { title: 'Legacy API' },
+        host: 'api.legacy.com',
+        basePath: '/v2',
+        schemes: ['https'],
+        paths: {
+          '/items': {
+            get: {
+              operationId: 'listItems',
+              responses: {
+                '200': { schema: { type: 'array' } },
+              },
+            },
+          },
+        },
+      });
+
+      const result = await parseOpenApiSpec({});
+
+      expect(result.title).toBe('Legacy API');
+      expect(result.baseUrl).toBe('https://api.legacy.com/v2');
+      expect(result.version).toBeNull();
+      expect(result.endpoints).toHaveLength(1);
+    });
+
+    it('throws when info.title is missing', async () => {
+      mockSwaggerParser.dereference.mockResolvedValue({
+        info: {},
+        paths: {},
+      });
+
+      await expect(parseOpenApiSpec('url')).rejects.toThrow('missing required info.title');
+    });
+
+    it('throws when no base URL can be resolved', async () => {
+      mockSwaggerParser.dereference.mockResolvedValue({
+        info: { title: 'No URL API' },
+        paths: {},
+      });
+
+      await expect(parseOpenApiSpec('url')).rejects.toThrow('Could not resolve base URL');
+    });
+
+    it('merges path-level and operation-level parameters', async () => {
+      mockSwaggerParser.dereference.mockResolvedValue({
+        info: { title: 'Params API', version: '1.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/users/{id}': {
+            parameters: [{ name: 'id', in: 'path' }],
+            get: {
+              operationId: 'getUser',
+              parameters: [{ name: 'fields', in: 'query' }],
+              responses: {},
+            },
+          },
+        },
+      });
+
+      const result = await parseOpenApiSpec('url');
+      expect(result.endpoints[0]!.parameters).toHaveLength(2);
+    });
+  });
+
+  describe('importEndpoints', () => {
+    it('inserts all endpoints when no selection filter is provided', async () => {
+      const parsedSpec = {
+        title: 'API',
+        version: '1.0',
+        baseUrl: 'https://api.example.com',
+        endpoints: [
+          { operationId: 'op1', method: 'get', path: '/a', summary: null, description: null, parameters: null, requestBody: null, responseSchema: null, tags: [] },
+          { operationId: 'op2', method: 'post', path: '/b', summary: null, description: null, parameters: null, requestBody: null, responseSchema: null, tags: [] },
+        ],
+      };
+
+      const inserted = [{ id: 'entry-1' }, { id: 'entry-2' }];
+      mockDb.insert.mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue(inserted),
+        }),
+      });
+
+      const result = await importEndpoints('user-1', parsedSpec, 'https://spec.url');
+
+      expect(result).toHaveLength(2);
+      expect(mockDb.insert).toHaveBeenCalled();
+    });
+
+    it('filters to selected paths when provided', async () => {
+      const parsedSpec = {
+        title: 'API',
+        version: '1.0',
+        baseUrl: 'https://api.example.com',
+        endpoints: [
+          { operationId: 'op1', method: 'get', path: '/a', summary: null, description: null, parameters: null, requestBody: null, responseSchema: null, tags: [] },
+          { operationId: 'op2', method: 'post', path: '/b', summary: null, description: null, parameters: null, requestBody: null, responseSchema: null, tags: [] },
+        ],
+      };
+
+      mockDb.insert.mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: 'entry-1' }]),
+        }),
+      });
+
+      const result = await importEndpoints('user-1', parsedSpec, null, [{ method: 'get', path: '/a' }]);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('returns empty array when no endpoints match selection', async () => {
+      const parsedSpec = {
+        title: 'API',
+        version: '1.0',
+        baseUrl: 'https://api.example.com',
+        endpoints: [
+          { operationId: 'op1', method: 'get', path: '/a', summary: null, description: null, parameters: null, requestBody: null, responseSchema: null, tags: [] },
+        ],
+      };
+
+      const result = await importEndpoints('user-1', parsedSpec, null, [{ method: 'delete', path: '/z' }]);
+
+      expect(result).toEqual([]);
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listToolRegistry', () => {
+    it('queries by userId', async () => {
+      const mockRows = [{ id: 'entry-1' }];
+      mockDb.select.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(mockRows),
+        }),
+      });
+
+      const result = await listToolRegistry('user-1');
+      expect(result).toEqual(mockRows);
+    });
+  });
+
+  describe('deleteSpec', () => {
+    it('returns count of deleted rows', async () => {
+      mockDb.delete.mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: 'e1' }, { id: 'e2' }]),
+        }),
+      });
+
+      const count = await deleteSpec('user-1', 'spec-1');
+      expect(count).toBe(2);
+    });
+  });
+
+  describe('toggleEndpoint', () => {
+    it('returns updated entry on success', async () => {
+      const updated = { id: 'entry-1', isEnabled: true };
+      mockDb.update.mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([updated]),
+          }),
+        }),
+      });
+
+      const result = await toggleEndpoint('user-1', 'entry-1', true);
+      expect(result).toEqual(updated);
+    });
+
+    it('returns null when no entry matches', async () => {
+      mockDb.update.mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      const result = await toggleEndpoint('user-1', 'nonexistent', false);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/services/akasa-server/src/__tests__/skill-learning.test.ts
+++ b/services/akasa-server/src/__tests__/skill-learning.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockDb, mockGenerateText } = vi.hoisted(() => ({
+  mockDb: { select: vi.fn(), insert: vi.fn() },
+  mockGenerateText: vi.fn(),
+}));
+
+vi.mock('@claw/db', () => ({
+  db: mockDb,
+  decisionTraces: {
+    executionId: 'executionId',
+    botId: 'botId',
+    decisionId: 'decisionId',
+    decisionType: 'decisionType',
+    directiveReferenced: 'directiveReferenced',
+    attributionConfidence: 'attributionConfidence',
+    outcome: 'outcome',
+    metadata: 'metadata',
+  },
+  learnedSkills: {
+    soulId: 'soulId',
+    skillContent: 'skillContent',
+  },
+  botSouls: {
+    id: 'id',
+    taskCategory: 'taskCategory',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: (...args: unknown[]) => ({ _type: 'eq', args }),
+  and: (...args: unknown[]) => ({ _type: 'and', args }),
+}));
+
+vi.mock('ai', () => ({
+  generateText: (...args: unknown[]) => mockGenerateText(...args),
+  Output: {
+    object: (opts: unknown) => ({ _type: 'output_object', opts }),
+  },
+}));
+
+vi.mock('@ai-sdk/openai', () => ({
+  openai: vi.fn().mockReturnValue('mock-model'),
+}));
+
+vi.mock('zod', () => {
+  const mockSchema: any = {};
+  mockSchema.min = vi.fn().mockReturnValue(mockSchema);
+  mockSchema.max = vi.fn().mockReturnValue(mockSchema);
+  mockSchema.array = vi.fn().mockReturnValue(mockSchema);
+
+  return {
+    z: {
+      object: vi.fn().mockReturnValue(mockSchema),
+      string: vi.fn().mockReturnValue(mockSchema),
+      number: vi.fn().mockReturnValue(mockSchema),
+      array: vi.fn().mockReturnValue(mockSchema),
+      infer: vi.fn(),
+    },
+  };
+});
+
+import { processSkillLearningForExecution } from '../services/skill-learning.js';
+
+function makeSelectChain(data: unknown[]) {
+  const whereResult = Object.assign(Promise.resolve(data), {
+    limit: vi.fn().mockResolvedValue(data),
+  });
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue(whereResult),
+    }),
+  };
+}
+
+describe('skill-learning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns zero skills when no decision traces exist', async () => {
+    mockDb.select.mockReturnValue(makeSelectChain([]));
+
+    const result = await processSkillLearningForExecution('exec-1', 'bot-1', null);
+
+    expect(result.skillsCreated).toBe(0);
+    expect(result.skillIds).toEqual([]);
+  });
+
+  it('returns zero skills when no successful traces exist', async () => {
+    const traces = [
+      {
+        decisionId: 'd1',
+        decisionType: 'tool_call',
+        directiveReferenced: null,
+        attributionConfidence: '0.3', // below 0.5 threshold
+        outcome: 'success',
+        metadata: {},
+      },
+      {
+        decisionId: 'd2',
+        decisionType: 'tool_call',
+        directiveReferenced: null,
+        attributionConfidence: '0.9',
+        outcome: 'failure', // not success
+        metadata: {},
+      },
+    ];
+
+    mockDb.select.mockReturnValue(makeSelectChain(traces));
+
+    const result = await processSkillLearningForExecution('exec-1', 'bot-1', null);
+
+    expect(result.skillsCreated).toBe(0);
+  });
+
+  it('returns zero skills when LLM detects no novel patterns', async () => {
+    const traces = [
+      {
+        decisionId: 'd1',
+        decisionType: 'tool_call',
+        directiveReferenced: 'Be safe',
+        attributionConfidence: '0.9',
+        outcome: 'success',
+        metadata: {},
+      },
+    ];
+
+    let selectCall = 0;
+    mockDb.select.mockImplementation(() => {
+      selectCall++;
+      if (selectCall === 1) return makeSelectChain(traces);
+      if (selectCall === 2) return makeSelectChain([{ taskCategory: 'research' }]); // botSouls lookup
+      return makeSelectChain([]); // existing skills
+    });
+
+    mockGenerateText.mockResolvedValue({ output: [] });
+
+    const result = await processSkillLearningForExecution('exec-1', 'bot-1', 'soul-1');
+
+    expect(result.skillsCreated).toBe(0);
+  });
+
+  it('creates skills when LLM identifies novel patterns above confidence threshold', async () => {
+    const traces = [
+      {
+        decisionId: 'd1',
+        decisionType: 'reasoning',
+        directiveReferenced: null,
+        attributionConfidence: '0.9',
+        outcome: 'success',
+        metadata: {},
+      },
+    ];
+
+    let selectCall = 0;
+    mockDb.select.mockImplementation(() => {
+      selectCall++;
+      if (selectCall === 1) return makeSelectChain(traces);
+      if (selectCall === 2) return makeSelectChain([{ taskCategory: 'coding' }]);
+      if (selectCall === 3) return makeSelectChain([]); // existing skills
+      // computeAverageConfidence lookup
+      return makeSelectChain([{ attributionConfidence: '0.9' }]);
+    });
+
+    mockGenerateText.mockResolvedValue({
+      output: [
+        {
+          name: 'error-recovery-pattern',
+          category: 'recovery',
+          triggerPatterns: ['When encountering a 500 error'],
+          proceduralBody: '1. Retry\n2. Log\n3. Fallback',
+          requiredTools: [],
+          confidenceScore: 0.85,
+          reasoning: 'Consistent error recovery pattern across traces',
+        },
+      ],
+    });
+
+    mockDb.insert.mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([
+          {
+            id: 'skill-new-1',
+            name: 'error-recovery-pattern',
+            confidenceScore: '0.875',
+            approvalStatus: 'auto_approved',
+            sourceTraceIds: ['d1'],
+          },
+        ]),
+      }),
+    });
+
+    const result = await processSkillLearningForExecution('exec-1', 'bot-1', 'soul-1');
+
+    expect(result.skillsCreated).toBe(1);
+    expect(result.skillIds).toEqual(['skill-new-1']);
+  });
+});

--- a/services/akasa-server/src/__tests__/skill-unlearning.test.ts
+++ b/services/akasa-server/src/__tests__/skill-unlearning.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    select: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    insert: vi.fn(),
+    transaction: vi.fn(),
+  },
+}));
+
+vi.mock('@claw/db', () => ({
+  db: mockDb,
+  skillActivations: {
+    id: 'id',
+    botId: 'botId',
+    skillId: 'skillId',
+    classification: 'classification',
+    consecutiveNegativeCount: 'consecutiveNegativeCount',
+  },
+  skillLoadouts: {
+    botId: 'botId',
+    skillId: 'skillId',
+    isActive: 'isActive',
+    removedAt: 'removedAt',
+  },
+  negativeSignalRegister: {},
+  agentSkills: {
+    id: 'id',
+    skillName: 'skillName',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: (...args: unknown[]) => ({ _type: 'eq', args }),
+  and: (...args: unknown[]) => ({ _type: 'and', args }),
+}));
+
+vi.mock('@claw/event-schemas/skill-events', () => ({
+  skillUnlearnedEventSchema: {
+    parse: vi.fn(),
+  },
+}));
+
+import { processSkillUnlearning } from '../god-layer/skill-unlearning.js';
+
+describe('skill-unlearning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns empty unlearnedSkills when no activations exist', async () => {
+    mockDb.select.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    });
+
+    const result = await processSkillUnlearning('bot-1', 'exec-1', null, 'Maintain');
+
+    expect(result.unlearnedSkills).toEqual([]);
+  });
+
+  it('resets consecutiveNegativeCount when classification is positive', async () => {
+    mockDb.select.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            {
+              activation: {
+                id: 'act-1',
+                skillId: 'skill-1',
+                classification: 'positive',
+                consecutiveNegativeCount: 1,
+              },
+              skillName: 'test-skill',
+            },
+          ]),
+        }),
+      }),
+    });
+
+    mockDb.update.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    });
+
+    const result = await processSkillUnlearning('bot-1', 'exec-1', null, 'Maintain');
+
+    expect(result.unlearnedSkills).toEqual([]);
+    expect(mockDb.update).toHaveBeenCalled();
+  });
+
+  it('increments consecutiveNegativeCount but does not unlearn when below threshold', async () => {
+    mockDb.select.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            {
+              activation: {
+                id: 'act-1',
+                skillId: 'skill-1',
+                classification: 'negative',
+                consecutiveNegativeCount: 0, // will become 1, threshold is 2
+              },
+              skillName: 'test-skill',
+            },
+          ]),
+        }),
+      }),
+    });
+
+    mockDb.update.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    });
+
+    const result = await processSkillUnlearning('bot-1', 'exec-1', null, 'Monitor');
+
+    expect(result.unlearnedSkills).toEqual([]);
+  });
+
+  it('unlearns skill when consecutiveNegativeCount reaches threshold', async () => {
+    mockDb.select.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            {
+              activation: {
+                id: 'act-1',
+                skillId: 'skill-1',
+                classification: 'negative',
+                consecutiveNegativeCount: 1, // will become 2, equals threshold
+              },
+              skillName: 'underperforming-skill',
+            },
+          ]),
+        }),
+      }),
+    });
+
+    // Transaction mock
+    mockDb.transaction.mockImplementation(async (cb: Function) => {
+      const tx = {
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+          }),
+        }),
+        delete: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockResolvedValue(undefined),
+        }),
+      };
+      await cb(tx);
+    });
+
+    const result = await processSkillUnlearning('bot-1', 'exec-1', 'soul-1', 'Demote');
+
+    expect(result.unlearnedSkills).toHaveLength(1);
+    expect(result.unlearnedSkills[0]!.skillId).toBe('skill-1');
+    expect(result.unlearnedSkills[0]!.skillName).toBe('underperforming-skill');
+    expect(result.unlearnedSkills[0]!.reason).toContain('consecutive negative');
+  });
+
+  it('triggers unlearning when verdict is Demote even with non-negative classification', async () => {
+    mockDb.select.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            {
+              activation: {
+                id: 'act-1',
+                skillId: 'skill-1',
+                classification: 'neutral',
+                consecutiveNegativeCount: 1, // Demote triggers increment: 1+1=2 >= threshold
+              },
+              skillName: 'mediocre-skill',
+            },
+          ]),
+        }),
+      }),
+    });
+
+    mockDb.transaction.mockImplementation(async (cb: Function) => {
+      const tx = {
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+          }),
+        }),
+        delete: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockResolvedValue(undefined),
+        }),
+      };
+      await cb(tx);
+    });
+
+    const result = await processSkillUnlearning('bot-1', 'exec-1', null, 'Demote');
+
+    expect(result.unlearnedSkills).toHaveLength(1);
+  });
+});

--- a/services/execution-service/src/__tests__/services/agent-session-builder.test.ts
+++ b/services/execution-service/src/__tests__/services/agent-session-builder.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import {
+  verifyConstitution,
+  buildAgentSessionPrompt,
+  type BuildParams,
+} from '../../services/agent-session-builder.js';
+
+describe('agent-session-builder', () => {
+  describe('verifyConstitution', () => {
+    it('returns verified=true when no directives are expected', () => {
+      const result = verifyConstitution('any soul content', []);
+      expect(result.verified).toBe(true);
+      expect(result.missing).toHaveLength(0);
+    });
+
+    it('returns verified=true when all directives are present in soul content', () => {
+      const soulContent = 'INVIOLABLE: Never harm users\nINVIOLABLE: Always be honest';
+      const directives = ['INVIOLABLE: Never harm users', 'INVIOLABLE: Always be honest'];
+      const result = verifyConstitution(soulContent, directives);
+      expect(result.verified).toBe(true);
+      expect(result.missing).toHaveLength(0);
+    });
+
+    it('returns verified=false with missing directives when some are absent', () => {
+      const soulContent = 'INVIOLABLE: Never harm users';
+      const directives = ['INVIOLABLE: Never harm users', 'INVIOLABLE: Always be honest'];
+      const result = verifyConstitution(soulContent, directives);
+      expect(result.verified).toBe(false);
+      expect(result.missing).toEqual(['INVIOLABLE: Always be honest']);
+    });
+
+    it('trims whitespace before comparing', () => {
+      const soulContent = 'INVIOLABLE: Never harm users';
+      const directives = ['  INVIOLABLE: Never harm users  '];
+      const result = verifyConstitution(soulContent, directives);
+      expect(result.verified).toBe(true);
+    });
+  });
+
+  describe('buildAgentSessionPrompt', () => {
+    function makeParams(overrides: Partial<BuildParams> = {}): BuildParams {
+      return {
+        soulContent: '# SOUL.md\nINVIOLABLE: Be safe\n## Identity\nI am a test agent.',
+        constitutionDirectives: ['INVIOLABLE: Be safe'],
+        taskDescription: 'Analyze the dataset',
+        taskId: 'task-1',
+        requiredTools: ['browser', 'code_runner'],
+        complexity: 'medium',
+        upstreamOutputs: null,
+        ...overrides,
+      };
+    }
+
+    it('includes soul content, task brief, and footer in fullPrompt', () => {
+      const result = buildAgentSessionPrompt(makeParams());
+
+      expect(result.fullPrompt).toContain('# SOUL.md');
+      expect(result.fullPrompt).toContain('## Task Assignment');
+      expect(result.fullPrompt).toContain('Task ID: task-1');
+      expect(result.fullPrompt).toContain('Complexity: medium');
+      expect(result.fullPrompt).toContain('browser, code_runner');
+      expect(result.fullPrompt).toContain('Analyze the dataset');
+      expect(result.fullPrompt).toContain('You are bound by the SOUL.md constitution');
+    });
+
+    it('sets constitutionVerified=true when all directives present', () => {
+      const result = buildAgentSessionPrompt(makeParams());
+      expect(result.constitutionVerified).toBe(true);
+    });
+
+    it('sets constitutionVerified=false when directives are missing', () => {
+      const result = buildAgentSessionPrompt(
+        makeParams({ constitutionDirectives: ['INVIOLABLE: Missing directive'] }),
+      );
+      expect(result.constitutionVerified).toBe(false);
+    });
+
+    it('includes upstream intelligence when provided', () => {
+      const result = buildAgentSessionPrompt(
+        makeParams({
+          upstreamOutputs: [
+            { taskId: 'task-0', summary: 'Upstream result summary' },
+          ],
+        }),
+      );
+
+      expect(result.fullPrompt).toContain('## Upstream Intelligence');
+      expect(result.fullPrompt).toContain('### Task task-0');
+      expect(result.fullPrompt).toContain('Upstream result summary');
+      expect(result.upstreamIntelligence).not.toBeNull();
+    });
+
+    it('omits upstream intelligence when upstreamOutputs is null', () => {
+      const result = buildAgentSessionPrompt(makeParams());
+      expect(result.fullPrompt).not.toContain('## Upstream Intelligence');
+      expect(result.upstreamIntelligence).toBeNull();
+    });
+
+    it('omits upstream intelligence when upstreamOutputs is empty', () => {
+      const result = buildAgentSessionPrompt(makeParams({ upstreamOutputs: [] }));
+      expect(result.upstreamIntelligence).toBeNull();
+    });
+
+    it('displays "(none specified)" when requiredTools is empty', () => {
+      const result = buildAgentSessionPrompt(makeParams({ requiredTools: [] }));
+      expect(result.taskBrief).toContain('(none specified)');
+    });
+
+    it('returns all expected fields', () => {
+      const result = buildAgentSessionPrompt(makeParams());
+      expect(result).toHaveProperty('fullPrompt');
+      expect(result).toHaveProperty('soulContent');
+      expect(result).toHaveProperty('constitutionVerified');
+      expect(result).toHaveProperty('constitutionDirectives');
+      expect(result).toHaveProperty('taskBrief');
+      expect(result).toHaveProperty('upstreamIntelligence');
+    });
+  });
+});

--- a/services/execution-service/src/__tests__/services/budget-validator.test.ts
+++ b/services/execution-service/src/__tests__/services/budget-validator.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import {
+  estimatePopulationCost,
+  applyTieredReduction,
+  validateBudget,
+  AGENT_COST_CENTS,
+} from '../../services/budget-validator.js';
+import type { PopulationManifest } from '@claw/shared-types';
+
+function makeManifest(overrides: Partial<PopulationManifest> = {}): PopulationManifest {
+  return {
+    taskId: 'task-1',
+    taskDescription: 'Test task',
+    assignedSouls: [
+      {
+        soulId: 'soul-1',
+        agentClass: 'Novice',
+        source: 'archetype',
+        differentiationScore: 0.5,
+        selectionRationale: 'test rationale',
+      },
+    ],
+    pioneerFlag: false,
+    ...overrides,
+  };
+}
+
+describe('budget-validator', () => {
+  describe('estimatePopulationCost', () => {
+    it('returns 0 for empty manifests', () => {
+      expect(estimatePopulationCost([])).toBe(0);
+    });
+
+    it('sums costs across all souls in all manifests', () => {
+      const manifests = [
+        makeManifest({
+          assignedSouls: [
+            { soulId: 's1', agentClass: 'Artisan', source: 'library', differentiationScore: 0.5, selectionRationale: '' },
+            { soulId: 's2', agentClass: 'Understudy', source: 'library', differentiationScore: 0.5, selectionRationale: '' },
+          ],
+        }),
+        makeManifest({
+          taskId: 'task-2',
+          assignedSouls: [
+            { soulId: 's3', agentClass: 'Novice', source: 'archetype', differentiationScore: 0.5, selectionRationale: '' },
+          ],
+        }),
+      ];
+
+      const expected = AGENT_COST_CENTS.Artisan + AGENT_COST_CENTS.Understudy + AGENT_COST_CENTS.Novice;
+      expect(estimatePopulationCost(manifests)).toBe(expected);
+    });
+  });
+
+  describe('applyTieredReduction', () => {
+    it('replaces Artisans with Understudies in Tier 1', () => {
+      const manifests = [
+        makeManifest({
+          assignedSouls: [
+            { soulId: 's1', agentClass: 'Artisan', source: 'library', differentiationScore: 0.5, selectionRationale: '' },
+            { soulId: 's2', agentClass: 'Artisan', source: 'library', differentiationScore: 0.5, selectionRationale: '' },
+          ],
+        }),
+      ];
+
+      const { manifests: reduced, warnings } = applyTieredReduction(manifests, 200);
+
+      for (const soul of reduced[0]!.assignedSouls) {
+        expect(soul.agentClass).toBe('Understudy');
+      }
+      expect(warnings.some((w) => w.includes('Tier 1'))).toBe(true);
+    });
+
+    it('applies Tier 2 reduction when Tier 1 is insufficient', () => {
+      const souls = Array.from({ length: 10 }, (_, i) => ({
+        soulId: `s${i}`,
+        agentClass: 'Understudy' as const,
+        source: 'library' as const,
+        differentiationScore: 0.5,
+        selectionRationale: '',
+      }));
+
+      const manifests = [makeManifest({ assignedSouls: souls })];
+      // MIN_AGENTS_PER_TASK is 3, cost = 3 * 50 = 150
+      const { manifests: reduced, warnings } = applyTieredReduction(manifests, 10);
+
+      expect(reduced[0]!.assignedSouls.length).toBe(3);
+      expect(warnings.some((w) => w.includes('Tier 2'))).toBe(true);
+    });
+
+    it('does not mutate the original manifests', () => {
+      const manifests = [
+        makeManifest({
+          assignedSouls: [
+            { soulId: 's1', agentClass: 'Artisan', source: 'library', differentiationScore: 0.5, selectionRationale: '' },
+          ],
+        }),
+      ];
+
+      applyTieredReduction(manifests, 10);
+
+      expect(manifests[0]!.assignedSouls[0]!.agentClass).toBe('Artisan');
+    });
+  });
+
+  describe('validateBudget', () => {
+    it('returns funded=true with no warnings when budgetCapCents is 0 (no-cap mode)', () => {
+      const manifests = [makeManifest()];
+      const result = validateBudget(manifests, 0);
+
+      expect(result.funded).toBe(true);
+      expect(result.warnings).toHaveLength(0);
+      expect(result.manifests).toBe(manifests); // same reference, no clone
+    });
+
+    it('returns funded=true when cost is within budget', () => {
+      const manifests = [makeManifest()]; // 1 Novice = 30 cents
+      const result = validateBudget(manifests, 1000);
+
+      expect(result.funded).toBe(true);
+      expect(result.warnings).toHaveLength(0);
+      expect(result.estimatedCostCents).toBe(30);
+    });
+
+    it('applies tiered reduction when over budget and returns reduced manifests', () => {
+      const manifests = [
+        makeManifest({
+          assignedSouls: [
+            { soulId: 's1', agentClass: 'Artisan', source: 'library', differentiationScore: 0.5, selectionRationale: '' },
+            { soulId: 's2', agentClass: 'Artisan', source: 'library', differentiationScore: 0.5, selectionRationale: '' },
+          ],
+        }),
+      ];
+      // 2 Artisans = 200 cents, budget = 150
+      // Tier 1: replace with Understudies = 100 cents, fits
+      const result = validateBudget(manifests, 150);
+
+      expect(result.funded).toBe(true);
+      expect(result.warnings.length).toBeGreaterThan(0);
+      expect(result.estimatedCostCents).toBeLessThanOrEqual(150);
+    });
+
+    it('returns funded=false with shortfall when reduction is insufficient', () => {
+      const souls = Array.from({ length: 5 }, (_, i) => ({
+        soulId: `s${i}`,
+        agentClass: 'Artisan' as const,
+        source: 'library' as const,
+        differentiationScore: 0.5,
+        selectionRationale: '',
+      }));
+
+      const manifests = [makeManifest({ assignedSouls: souls })];
+      // After Tier 1: 5 Understudies = 250. After Tier 2: 3 Understudies = 150. Budget = 10.
+      const result = validateBudget(manifests, 10);
+
+      expect(result.funded).toBe(false);
+      expect(result.shortfallCents).toBeGreaterThan(0);
+      expect(result.minimumRequiredCents).toBeDefined();
+    });
+  });
+});

--- a/services/execution-service/src/__tests__/services/coordination-events.test.ts
+++ b/services/execution-service/src/__tests__/services/coordination-events.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockPublishRingLeaderEvent = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../events/publisher.js', () => ({
+  publishRingLeaderEvent: (...args: unknown[]) => mockPublishRingLeaderEvent(...args),
+}));
+
+import {
+  logCoordinationEvent,
+  getCoordinationLog,
+  clearCoordinationLog,
+} from '../../services/coordination-events.js';
+
+describe('coordination-events', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear all logs between tests
+    clearCoordinationLog('run-1');
+    clearCoordinationLog('run-2');
+  });
+
+  describe('logCoordinationEvent', () => {
+    it('appends an event to the in-memory log', async () => {
+      const event = { type: 'intelligence_routing' as const, runId: 'run-1' } as any;
+      await logCoordinationEvent('run-1', 'exec-1', event);
+
+      const log = getCoordinationLog('run-1');
+      expect(log).toHaveLength(1);
+      expect(log[0]!.type).toBe('intelligence_routing');
+      expect(log[0]!.payload).toBe(event);
+      expect(log[0]!.timestamp).toBeDefined();
+    });
+
+    it('publishes the event via the publisher', async () => {
+      const event = { type: 'reallocation' as const } as any;
+      await logCoordinationEvent('run-1', 'exec-1', event);
+      expect(mockPublishRingLeaderEvent).toHaveBeenCalledWith(event);
+    });
+
+    it('appends multiple events in order', async () => {
+      const event1 = { type: 'intelligence_routing' as const } as any;
+      const event2 = { type: 'reallocation' as const } as any;
+
+      await logCoordinationEvent('run-1', 'exec-1', event1);
+      await logCoordinationEvent('run-1', 'exec-1', event2);
+
+      const log = getCoordinationLog('run-1');
+      expect(log).toHaveLength(2);
+      expect(log[0]!.type).toBe('intelligence_routing');
+      expect(log[1]!.type).toBe('reallocation');
+    });
+
+    it('maintains separate logs for different runIds', async () => {
+      const event1 = { type: 'intelligence_routing' as const } as any;
+      const event2 = { type: 'reallocation' as const } as any;
+
+      await logCoordinationEvent('run-1', 'exec-1', event1);
+      await logCoordinationEvent('run-2', 'exec-2', event2);
+
+      expect(getCoordinationLog('run-1')).toHaveLength(1);
+      expect(getCoordinationLog('run-2')).toHaveLength(1);
+    });
+  });
+
+  describe('getCoordinationLog', () => {
+    it('returns empty array for unknown runId', () => {
+      expect(getCoordinationLog('nonexistent')).toEqual([]);
+    });
+  });
+
+  describe('clearCoordinationLog', () => {
+    it('removes all events for a given runId', async () => {
+      const event = { type: 'intelligence_routing' as const } as any;
+      await logCoordinationEvent('run-1', 'exec-1', event);
+
+      expect(getCoordinationLog('run-1')).toHaveLength(1);
+
+      clearCoordinationLog('run-1');
+
+      expect(getCoordinationLog('run-1')).toEqual([]);
+    });
+
+    it('does not throw when clearing a nonexistent runId', () => {
+      expect(() => clearCoordinationLog('nonexistent')).not.toThrow();
+    });
+  });
+});

--- a/services/execution-service/src/__tests__/services/cost-projection.test.ts
+++ b/services/execution-service/src/__tests__/services/cost-projection.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: { select: vi.fn() },
+}));
+
+vi.mock('@claw/db', () => ({
+  db: mockDb,
+  billingEvents: {
+    occurredAt: 'occurredAt',
+    amountCents: 'amountCents',
+    tokenCount: 'tokenCount',
+    eventType: 'eventType',
+    metadata: 'metadata',
+  },
+  telemetry: {
+    computedAt: 'computedAt',
+    metricValue: 'metricValue',
+    metricName: 'metricName',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ..._values: unknown[]) => ({
+      _type: 'sql',
+      text: strings.join('?'),
+    }),
+    { raw: (s: string) => ({ _type: 'sql_raw', text: s }) },
+  ),
+  gte: (...args: unknown[]) => ({ _type: 'gte', args }),
+  and: (...args: unknown[]) => ({ _type: 'and', args }),
+}));
+
+import { calculateCostProjection } from '../../services/cost-projection.js';
+
+function makeChain(data: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        groupBy: vi.fn().mockResolvedValue(data),
+      }),
+    }),
+  };
+}
+
+function makeSimpleChain(data: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(data),
+    }),
+  };
+}
+
+describe('cost-projection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env['BOT_HOURLY_RATE_CENTS'];
+  });
+
+  it('returns zero burn rate when no billing events or telemetry exist', async () => {
+    let callCount = 0;
+    mockDb.select.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // dailySpend query — has groupBy
+        return makeChain([]);
+      }
+      if (callCount === 2) {
+        // botHoursResult query — no groupBy
+        return makeSimpleChain([{ totalHours: 0 }]);
+      }
+      // dimensionBreakdown query — no groupBy
+      return makeSimpleChain([{ totalInputCents: 0, totalOutputCents: 0, totalToolCents: 0 }]);
+    });
+
+    const result = await calculateCostProjection(null, null, 0);
+
+    expect(result.dailyBurnRateCents).toBe(0);
+    expect(result.dataPoints).toBe(0);
+    expect(result.trend).toBe('stable');
+    expect(result.daysUntilBudgetExhaustion).toBeNull();
+  });
+
+  it('calculates daily burn rate from billing events', async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    let callCount = 0;
+    mockDb.select.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return makeChain([
+          { day: today, totalCents: 300, tokenCount: 1000, eventCount: 5 },
+        ]);
+      }
+      if (callCount === 2) {
+        return makeSimpleChain([{ totalHours: 0 }]);
+      }
+      return makeSimpleChain([{ totalInputCents: 100, totalOutputCents: 100, totalToolCents: 100 }]);
+    });
+
+    const result = await calculateCostProjection(null, null, 0);
+
+    expect(result.dailyBurnRateCents).toBe(300); // 300 / 1 active day
+    expect(result.dataPoints).toBe(1);
+  });
+
+  it('includes bot hours cost in burn rate', async () => {
+    process.env['BOT_HOURLY_RATE_CENTS'] = '200';
+    let callCount = 0;
+    mockDb.select.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return makeChain([]);
+      }
+      if (callCount === 2) {
+        return makeSimpleChain([{ totalHours: 5 }]);
+      }
+      return makeSimpleChain([{ totalInputCents: 0, totalOutputCents: 0, totalToolCents: 0 }]);
+    });
+
+    const result = await calculateCostProjection(null, null, 0);
+
+    // 5 hours * 200 cents/hour = 1000 cents
+    expect(result.dailyBurnRateCents).toBe(1000);
+    expect(result.breakdown.botHoursCents).toBe(1000);
+  });
+
+  it('calculates daysUntilBudgetExhaustion with monthly budget', async () => {
+    let callCount = 0;
+    const today = new Date().toISOString().slice(0, 10);
+    mockDb.select.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return makeChain([
+          { day: today, totalCents: 100, tokenCount: 100, eventCount: 1 },
+        ]);
+      }
+      if (callCount === 2) {
+        return makeSimpleChain([{ totalHours: 0 }]);
+      }
+      return makeSimpleChain([{ totalInputCents: 50, totalOutputCents: 50, totalToolCents: 0 }]);
+    });
+
+    const result = await calculateCostProjection(null, 1000, 200);
+
+    // Remaining budget: 1000 - 200 = 800. Daily burn: 100. Days: floor(800/100) = 8
+    expect(result.daysUntilBudgetExhaustion).toBe(8);
+  });
+
+  it('returns daysUntilBudgetExhaustion=0 when budget is already exhausted', async () => {
+    let callCount = 0;
+    const today = new Date().toISOString().slice(0, 10);
+    mockDb.select.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return makeChain([
+          { day: today, totalCents: 100, tokenCount: 100, eventCount: 1 },
+        ]);
+      }
+      if (callCount === 2) {
+        return makeSimpleChain([{ totalHours: 0 }]);
+      }
+      return makeSimpleChain([{ totalInputCents: 50, totalOutputCents: 50, totalToolCents: 0 }]);
+    });
+
+    const result = await calculateCostProjection(null, 500, 600);
+
+    expect(result.daysUntilBudgetExhaustion).toBe(0);
+  });
+
+  it('detects increasing trend when second half spend exceeds first half by >10%', async () => {
+    const now = new Date();
+    const earlyDay = new Date(now.getTime() - 6 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const lateDay = new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+    let callCount = 0;
+    mockDb.select.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return makeChain([
+          { day: earlyDay, totalCents: 100, tokenCount: 100, eventCount: 1 },
+          { day: lateDay, totalCents: 200, tokenCount: 200, eventCount: 2 },
+        ]);
+      }
+      if (callCount === 2) {
+        return makeSimpleChain([{ totalHours: 0 }]);
+      }
+      return makeSimpleChain([{ totalInputCents: 150, totalOutputCents: 150, totalToolCents: 0 }]);
+    });
+
+    const result = await calculateCostProjection(null, null, 0);
+
+    expect(result.trend).toBe('increasing');
+  });
+
+  it('returns windowDays=7', async () => {
+    let callCount = 0;
+    mockDb.select.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return makeChain([]);
+      if (callCount === 2) return makeSimpleChain([{ totalHours: 0 }]);
+      return makeSimpleChain([{ totalInputCents: 0, totalOutputCents: 0, totalToolCents: 0 }]);
+    });
+
+    const result = await calculateCostProjection(null, null, 0);
+    expect(result.windowDays).toBe(7);
+  });
+});

--- a/services/execution-service/src/__tests__/services/evolution-campaign-hook.test.ts
+++ b/services/execution-service/src/__tests__/services/evolution-campaign-hook.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockDb, mockAllVerdictsProcessed, mockComputeExecutionFitness, mockEvaluateHaltCriteria, mockEvolutionCampaignQueue } = vi.hoisted(() => ({
+  mockDb: { select: vi.fn(), update: vi.fn() },
+  mockAllVerdictsProcessed: vi.fn(),
+  mockComputeExecutionFitness: vi.fn(),
+  mockEvaluateHaltCriteria: vi.fn(),
+  mockEvolutionCampaignQueue: { add: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock('@claw/db', () => ({
+  db: mockDb,
+  executions: { id: 'id', evolutionCampaignId: 'evolutionCampaignId' },
+  evolutionCampaigns: {
+    id: 'id',
+    completedIterationCount: 'completedIterationCount',
+    bestEfsScore: 'bestEfsScore',
+    status: 'status',
+    stoppedAt: 'stoppedAt',
+    updatedAt: 'updatedAt',
+  },
+  evolutionCampaignIterations: {
+    id: 'id',
+    executionId: 'executionId',
+    campaignId: 'campaignId',
+    iterationNum: 'iterationNum',
+    completedAt: 'completedAt',
+    efsScore: 'efsScore',
+    successRate: 'successRate',
+    costEfficiency: 'costEfficiency',
+    speed: 'speed',
+    councilHealth: 'councilHealth',
+    deltaFromPrevious: 'deltaFromPrevious',
+    haltedReason: 'haltedReason',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: (...args: unknown[]) => ({ _type: 'eq', args }),
+  and: (...args: unknown[]) => ({ _type: 'and', args }),
+  isNull: (col: unknown) => ({ _type: 'isNull', col }),
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ..._values: unknown[]) => ({
+      _type: 'sql',
+      text: strings.join('?'),
+    }),
+    { raw: (s: string) => ({ _type: 'sql_raw', text: s }) },
+  ),
+}));
+
+vi.mock('../../services/execution-fitness.js', () => ({
+  computeExecutionFitness: (...args: unknown[]) => mockComputeExecutionFitness(...args),
+  allVerdictsProcessed: (...args: unknown[]) => mockAllVerdictsProcessed(...args),
+}));
+
+vi.mock('../../services/campaign-halt-criteria.js', () => ({
+  evaluateHaltCriteria: (...args: unknown[]) => mockEvaluateHaltCriteria(...args),
+}));
+
+vi.mock('../../queue/evolution-campaign-queue.js', () => ({
+  evolutionCampaignQueue: mockEvolutionCampaignQueue,
+}));
+
+import { runEvolutionCampaignHook } from '../../services/evolution-campaign-hook.js';
+
+function makeSelectChain(data: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(data),
+    }),
+  };
+}
+
+function makeUpdateChain(returningData?: unknown[]) {
+  const chain = {
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue(
+        returningData !== undefined
+          ? { returning: vi.fn().mockResolvedValue(returningData) }
+          : Promise.resolve(),
+      ),
+    }),
+  };
+  return chain;
+}
+
+describe('evolution-campaign-hook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exits silently when execution is not found', async () => {
+    mockDb.select.mockReturnValue(makeSelectChain([]));
+
+    await runEvolutionCampaignHook('exec-missing');
+
+    expect(mockComputeExecutionFitness).not.toHaveBeenCalled();
+  });
+
+  it('exits silently when execution has no campaign', async () => {
+    mockDb.select.mockReturnValue(
+      makeSelectChain([{ id: 'exec-1', evolutionCampaignId: null }]),
+    );
+
+    await runEvolutionCampaignHook('exec-1');
+
+    expect(mockAllVerdictsProcessed).not.toHaveBeenCalled();
+  });
+
+  it('exits when not all verdicts are processed', async () => {
+    mockDb.select.mockReturnValue(
+      makeSelectChain([{ id: 'exec-1', evolutionCampaignId: 'camp-1' }]),
+    );
+    mockAllVerdictsProcessed.mockResolvedValue(false);
+
+    await runEvolutionCampaignHook('exec-1');
+
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('exits when iteration claim returns empty (another worker already processed)', async () => {
+    mockDb.select.mockReturnValue(
+      makeSelectChain([{ id: 'exec-1', evolutionCampaignId: 'camp-1' }]),
+    );
+    mockAllVerdictsProcessed.mockResolvedValue(true);
+    // First update call = claim iteration, returns empty
+    mockDb.update.mockReturnValue(makeUpdateChain([]));
+
+    await runEvolutionCampaignHook('exec-1');
+
+    expect(mockComputeExecutionFitness).not.toHaveBeenCalled();
+  });
+
+  it('computes EFS, updates iteration and campaign, and enqueues next when halt=false', async () => {
+    // select for execution
+    let selectCall = 0;
+    mockDb.select.mockImplementation(() => {
+      selectCall++;
+      if (selectCall === 1) {
+        return makeSelectChain([{ id: 'exec-1', evolutionCampaignId: 'camp-1' }]);
+      }
+      // getPreviousIterationEfs — iteration 1 so null
+      return makeSelectChain([]);
+    });
+
+    mockAllVerdictsProcessed.mockResolvedValue(true);
+
+    // update calls: 1=claim iteration, 2=persist fitness, 3=update campaign
+    let updateCall = 0;
+    mockDb.update.mockImplementation(() => {
+      updateCall++;
+      if (updateCall === 1) {
+        // claim iteration — returns claimed row
+        return makeUpdateChain([{ id: 'iter-1', iterationNum: 1, campaignId: 'camp-1' }]);
+      }
+      // All other updates resolve without returning
+      return makeUpdateChain();
+    });
+
+    mockComputeExecutionFitness.mockResolvedValue({
+      efs: 0.75,
+      successRate: 0.8,
+      costEfficiency: 0.7,
+      speed: 0.6,
+      councilHealth: 0.9,
+    });
+
+    mockEvaluateHaltCriteria.mockResolvedValue({ halt: false, reason: null, detail: null });
+
+    await runEvolutionCampaignHook('exec-1');
+
+    expect(mockComputeExecutionFitness).toHaveBeenCalledWith('exec-1');
+    expect(mockEvolutionCampaignQueue.add).toHaveBeenCalledWith(
+      'next-iteration',
+      expect.objectContaining({
+        campaignId: 'camp-1',
+        previousIterationNum: 1,
+        previousExecutionId: 'exec-1',
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('marks campaign stopped and does not enqueue next when halt=true', async () => {
+    let selectCall = 0;
+    mockDb.select.mockImplementation(() => {
+      selectCall++;
+      if (selectCall === 1) {
+        return makeSelectChain([{ id: 'exec-1', evolutionCampaignId: 'camp-1' }]);
+      }
+      return makeSelectChain([]);
+    });
+
+    mockAllVerdictsProcessed.mockResolvedValue(true);
+
+    let updateCall = 0;
+    mockDb.update.mockImplementation(() => {
+      updateCall++;
+      if (updateCall === 1) {
+        return makeUpdateChain([{ id: 'iter-1', iterationNum: 3, campaignId: 'camp-1' }]);
+      }
+      return makeUpdateChain();
+    });
+
+    mockComputeExecutionFitness.mockResolvedValue({
+      efs: 0.95,
+      successRate: 0.95,
+      costEfficiency: 0.95,
+      speed: 0.95,
+      councilHealth: 0.95,
+    });
+
+    mockEvaluateHaltCriteria.mockResolvedValue({
+      halt: true,
+      reason: 'completed_success',
+      detail: 'Target EFS reached',
+    });
+
+    await runEvolutionCampaignHook('exec-1');
+
+    expect(mockEvolutionCampaignQueue.add).not.toHaveBeenCalled();
+    // Campaign update should have been called to mark stopped
+    expect(mockDb.update).toHaveBeenCalled();
+  });
+
+  it('does not rethrow on internal errors (non-fatal hook)', async () => {
+    mockDb.select.mockImplementation(() => {
+      throw new Error('DB connection lost');
+    });
+
+    // Should not throw
+    await expect(runEvolutionCampaignHook('exec-err')).resolves.toBeUndefined();
+  });
+});

--- a/services/execution-service/src/__tests__/services/run-synthesis.test.ts
+++ b/services/execution-service/src/__tests__/services/run-synthesis.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockDb, mockGenerateText, mockResolveModel } = vi.hoisted(() => ({
+  mockDb: { update: vi.fn() },
+  mockGenerateText: vi.fn(),
+  mockResolveModel: vi.fn().mockReturnValue('mock-model'),
+}));
+
+vi.mock('@claw/db', () => ({
+  db: mockDb,
+  ringLeaderRuns: {
+    id: 'id',
+    synthesis: 'synthesis',
+    status: 'status',
+    completedAt: 'completedAt',
+    updatedAt: 'updatedAt',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: (...args: unknown[]) => ({ _type: 'eq', args }),
+}));
+
+vi.mock('ai', () => ({
+  generateText: (...args: unknown[]) => mockGenerateText(...args),
+  Output: {
+    object: (opts: unknown) => ({ _type: 'output_object', opts }),
+  },
+}));
+
+vi.mock('zod', () => ({
+  z: {
+    object: vi.fn().mockReturnValue({
+      parse: vi.fn(),
+    }),
+    string: vi.fn().mockReturnValue({}),
+    boolean: vi.fn().mockReturnValue({}),
+  },
+}));
+
+vi.mock('../../lib/resolve-model.js', () => ({
+  resolveModel: (...args: unknown[]) => mockResolveModel(...args),
+}));
+
+import { generateRunSynthesis, type RunSynthesisParams } from '../../services/run-synthesis.js';
+
+function makeUpdateChain() {
+  return {
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    }),
+  };
+}
+
+function makeParams(overrides: Partial<RunSynthesisParams> = {}): RunSynthesisParams {
+  return {
+    runId: 'run-1',
+    executionId: 'exec-1',
+    missionBrief: {
+      objective: 'Test objective',
+      taskGraph: {
+        tasks: [
+          {
+            taskId: 'task-1',
+            description: 'Do the thing',
+            complexity: 'medium' as const,
+            requiredTools: ['browser'],
+          },
+        ],
+        dag: {},
+      },
+      toolGrants: [],
+      budgetCapCents: 1000,
+      runtimeLimitSeconds: 3600,
+      campaignType: 'ad_hoc',
+      runId: 'run-1',
+      projectId: null,
+    },
+    runState: {
+      runId: 'run-1',
+      elapsedTimeSeconds: 300,
+      budgetConsumedCents: 500,
+      taskStates: {
+        'task-1': {
+          status: 'complete',
+          outputQualitySignal: 0.85,
+        },
+      },
+      objectiveDriftScore: 0.1,
+      anomalies: [],
+    },
+    manifests: [
+      {
+        taskId: 'task-1',
+        taskDescription: 'Do the thing',
+        assignedSouls: [
+          {
+            soulId: 'soul-1',
+            agentClass: 'Understudy' as const,
+            source: 'archetype' as const,
+            differentiationScore: 0.5,
+            selectionRationale: 'Best fit',
+          },
+        ],
+        pioneerFlag: false,
+      },
+    ],
+    coordinationLog: [],
+    ...overrides,
+  };
+}
+
+describe('run-synthesis', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.update.mockImplementation(() => makeUpdateChain());
+  });
+
+  it('generates synthesis and persists it on successful LLM call', async () => {
+    mockGenerateText.mockResolvedValue({
+      output: {
+        objectiveAchieved: true,
+        achievementRationale: 'All tasks completed.',
+        soulSelectionRetrospective: 'Good soul picks.',
+        ringLeaderSelfAssessment: 'Coordination was efficient.',
+      },
+    });
+
+    const result = await generateRunSynthesis(makeParams());
+
+    expect(result.objectiveAchieved).toBe(true);
+    expect(result.runId).toBe('run-1');
+    expect(result.objective).toBe('Test objective');
+    expect(result.taskSummary).toHaveLength(1);
+    expect(result.budgetVarianceCents).toBe(-500); // 500 - 1000
+    expect(mockDb.update).toHaveBeenCalled();
+  });
+
+  it('falls back to degraded synthesis when LLM fails', async () => {
+    mockGenerateText.mockRejectedValue(new Error('API rate limited'));
+
+    const result = await generateRunSynthesis(makeParams());
+
+    expect(result.objectiveAchieved).toBe(false);
+    expect(result.achievementRationale).toContain('API rate limited');
+    expect(result.soulSelectionRetrospective).toBe('');
+    expect(result.ringLeaderSelfAssessment).toBe('');
+    // Should still persist
+    expect(mockDb.update).toHaveBeenCalled();
+  });
+
+  it('falls back when LLM returns null output', async () => {
+    mockGenerateText.mockResolvedValue({ output: null });
+
+    const result = await generateRunSynthesis(makeParams());
+
+    expect(result.objectiveAchieved).toBe(false);
+    expect(result.achievementRationale).toContain('failed');
+  });
+
+  it('counts coordination events by type', async () => {
+    mockGenerateText.mockResolvedValue({
+      output: {
+        objectiveAchieved: true,
+        achievementRationale: 'Done.',
+        soulSelectionRetrospective: 'OK.',
+        ringLeaderSelfAssessment: 'Fine.',
+      },
+    });
+
+    const params = makeParams({
+      coordinationLog: [
+        { type: 'intelligence_routing', timestamp: '2025-01-01T00:00:00Z', payload: {} as any },
+        { type: 'intelligence_routing', timestamp: '2025-01-01T00:01:00Z', payload: {} as any },
+        { type: 'reallocation', timestamp: '2025-01-01T00:02:00Z', payload: {} as any },
+        { type: 'reanchoring', timestamp: '2025-01-01T00:03:00Z', payload: {} as any },
+      ],
+    });
+
+    const result = await generateRunSynthesis(params);
+
+    expect(result.intelligenceRoutingEvents).toBe(2);
+    expect(result.reallocationEvents).toBe(1);
+    expect(result.reanchoringEvents).toBe(1);
+  });
+
+  it('identifies pioneer events from manifests with pioneerFlag', async () => {
+    mockGenerateText.mockResolvedValue({
+      output: {
+        objectiveAchieved: true,
+        achievementRationale: 'Done.',
+        soulSelectionRetrospective: 'OK.',
+        ringLeaderSelfAssessment: 'Fine.',
+      },
+    });
+
+    const params = makeParams({
+      manifests: [
+        {
+          taskId: 'task-1',
+          taskDescription: 'Pioneer task',
+          assignedSouls: [
+            { soulId: 'soul-1', agentClass: 'Understudy', source: 'archetype', differentiationScore: 0.5, selectionRationale: '' },
+          ],
+          pioneerFlag: true,
+        },
+        {
+          taskId: 'task-2',
+          taskDescription: 'Regular task',
+          assignedSouls: [
+            { soulId: 'soul-2', agentClass: 'Novice', source: 'archetype', differentiationScore: 0.3, selectionRationale: '' },
+          ],
+          pioneerFlag: false,
+        },
+      ],
+    });
+
+    const result = await generateRunSynthesis(params);
+
+    expect(result.pioneerEvents).toEqual(['task-1']);
+  });
+
+  it('derives recommended library writes from completed tasks with Artisan/Understudy souls', async () => {
+    mockGenerateText.mockResolvedValue({
+      output: {
+        objectiveAchieved: true,
+        achievementRationale: 'Done.',
+        soulSelectionRetrospective: 'OK.',
+        ringLeaderSelfAssessment: 'Fine.',
+      },
+    });
+
+    const params = makeParams({
+      runState: {
+        runId: 'run-1',
+        elapsedTimeSeconds: 300,
+        budgetConsumedCents: 500,
+        taskStates: {
+          'task-1': { status: 'complete', outputQualitySignal: 0.9 },
+        },
+        objectiveDriftScore: 0,
+        anomalies: [],
+      },
+      manifests: [
+        {
+          taskId: 'task-1',
+          taskDescription: 'Test',
+          assignedSouls: [
+            { soulId: 'soul-art', agentClass: 'Artisan', source: 'library', differentiationScore: 0.8, selectionRationale: '' },
+            { soulId: 'soul-nov', agentClass: 'Novice', source: 'archetype', differentiationScore: 0.3, selectionRationale: '' },
+          ],
+          pioneerFlag: false,
+        },
+      ],
+    });
+
+    const result = await generateRunSynthesis(params);
+
+    expect(result.recommendedLibraryWrites).toContain('soul-art');
+    expect(result.recommendedLibraryWrites).not.toContain('soul-nov');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 12 new test files covering previously untested service modules across `execution-service` and `akasa-server`
- Raises total passing test count from 615 to 702 (87 new tests)
- No source code changes -- tests only

### execution-service (6 files)
- `budget-validator` -- cost estimation, tiered reduction, budget validation
- `agent-session-builder` -- constitution verification, prompt assembly with upstream intelligence
- `coordination-events` -- in-memory event log, publish via event infrastructure, cleanup
- `cost-projection` -- daily burn rate, trend detection, budget exhaustion calculation
- `evolution-campaign-hook` -- Karpathy Loop post-verdict flow (claim iteration, EFS, halt criteria)
- `run-synthesis` -- LLM synthesis with fallback, pioneer/library write derivation

### akasa-server (6 files)
- `fleet-event-bus` -- singleton pattern, emit/subscribe/unsubscribe lifecycle
- `oauth-providers` -- provider registry completeness, getOAuthProvider lookup
- `openapi-import` -- OpenAPI 3.x/Swagger 2.x parsing, endpoint import with selection filtering
- `skill-learning` -- decision trace extraction, LLM novel pattern detection, DB persistence
- `skill-unlearning` -- consecutive negative count tracking, threshold-based auto-removal
- `god-layer-handler` -- class transition, DNA capture, negative signals, pioneer detection, skill learning/unlearning orchestration

Closes #35

## Test plan
- [x] `pnpm --filter @claw/execution-service exec vitest run` -- 555 passed, 8 skipped
- [x] `pnpm --filter @claw/akasa-server exec vitest run` -- 147 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)