### PR TITLE
docs: Update README with current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # Akasa
 
-Akasa is a D2C platform where anyone can acquire, deploy, and evolve AI agents to create compounding value. Users deploy fleets of AI bots against named objectives, and the evolutionary learning engine compounds agent intelligence through council-evaluated mutation and a versioned DNA library.
+Akasa is a D2C platform where anyone can acquire, deploy, and evolve AI agents to create compounding value.
+
+Users deploy fleets of AI bots against named objectives. The evolutionary learning engine compounds agent intelligence through council-evaluated mutation and a versioned DNA library -- the more you run, the smarter your agents get.
 
 Built on top of [Paperclip](https://github.com/paperclipai/paperclip), an open-source AI orchestration platform.
 
 ## Quick Start
 
 ```bash
-# Prerequisites: Node.js 22+, pnpm 10+, Docker
+# Prerequisites: Node.js 20+, pnpm 10+, Docker
 
 # Clone with submodule
 git clone --recurse-submodules https://github.com/tarikstafford/claw-army.git
@@ -23,17 +25,19 @@ docker compose -f docker-compose.dev.yml up -d
 docker exec postgres-db-1 apt-get install -y postgresql-17-pgvector
 docker exec postgres-db-1 psql -U postgres -d clawdb -c 'CREATE EXTENSION IF NOT EXISTS vector;'
 
-# Run migrations
+# Run migrations and seed data
 pnpm db:migrate
-
-# Seed archetypes (required before any execution)
 pnpm --filter @claw/db seed:archetypes
 
 # Start all services
 pnpm dev
 ```
 
-This starts the Paperclip Express backend (port 3100) and SvelteKit frontend (port 5173).
+This starts the Akasa backend and SvelteKit frontend (port 5173).
+
+> **Note:** pnpm 10.x does not pass inline env vars to child processes. Each service uses `.npmrc` with `node-options=--conditions=@claw/source` to resolve workspace packages to source in dev.
+
+See [docs/runbooks/local-dev.md](docs/runbooks/local-dev.md) for the full local development guide.
 
 ## Repository Structure
 
@@ -46,6 +50,7 @@ packages/
 
 services/
   akasa-server/    Fastify v5: evolution routes, Tool Nexus, OAuth, webhooks
+  execution-service/  Fastify v5: bot lifecycle, task dispatch, Council, God Layer
   ui/              SvelteKit v2 + Svelte 5: consumer UI (two-world design system)
   tool-gateway/    HTTP proxy + Tool Nexus invocation gateway
   telegram-bot/    Telegram <> Paperclip bridge (Command Channel)
@@ -61,32 +66,55 @@ docs/              Architecture, domain model, conventions, ADRs, runbooks
 
 ## Architecture
 
-See [docs/architecture.md](docs/architecture.md) for the full system architecture.
-
 **Two-repo model:**
 
-| Repo | Role |
-|------|------|
-| `claw-army` (this repo) | Akasa product: evolution engine, Tool Nexus, billing, UI |
-| `claw-paper-clip` (submodule) | Paperclip: agent orchestration, 7 adapters, plugin SDK |
+| Repo | Role | Hosting |
+|------|------|---------|
+| `claw-army` (this repo) | Akasa product: evolution engine, skills, Tool Nexus, billing, UI | Railway (app) + GCP (database, bot VMs) |
+| `claw-paper-clip` (submodule) | Paperclip: agent orchestration, 7 runtime adapters, plugin SDK | Railway |
 
-Akasa's backend calls Paperclip's Express API. All product logic lives here. Paperclip is an upstream dependency — never fork it.
+Akasa's backend calls Paperclip's API. All product logic lives here. Paperclip is an upstream dependency -- never fork it.
+
+**Key decisions:**
+- Bot execution on GCE VMs with OpenClaw (not containers)
+- Task dispatch via BullMQ (Redis) with concurrency=20
+- GCP Pub/Sub for inter-service events, SSE for real-time UI updates
+- SvelteKit reverse proxy (`/api/...`) so the browser never talks directly to the backend
+- All bot egress routes through Tool Gateway (`HTTP_PROXY`)
+
+See [docs/architecture.md](docs/architecture.md) for the full system architecture and data flows.
+
+## Services
+
+| Service | Description |
+|---------|-------------|
+| **akasa-server** | Evolution routes, Tool Nexus management, OAuth connections, webhook receiver |
+| **execution-service** | Bot lifecycle management, task dispatch, Council evaluation, God Layer transitions |
+| **ui** | SvelteKit consumer UI with two visual worlds (Screenplay light + Director's Cut dark) |
+| **tool-gateway** | HTTP forward proxy and Tool Nexus invocation gateway for bot internet access |
+| **telegram-bot** | Telegram bridge for the Command Channel (chat-first fleet management) |
+| **stub-bot** | BullMQ worker that simulates bot behavior for development and testing |
 
 ## Key Concepts
 
 | Term | Meaning |
 |------|---------|
-| **Execution** | A run of an objective — spawns bots, dispatches tasks, collects results |
-| **Bot** | An AI agent running on a GCE VM |
-| **Soul / SOUL.md** | Behavioral constitution (system prompt) with 7 dimensions |
-| **Council** | 3 LLM judges that evaluate agent performance |
-| **God Layer** | Post-council pipeline: class transitions, DNA writes, mutation prep |
-| **Agent Class** | Novice → Understudy → Artisan → Retired |
-| **DNA Store** | Captured behavioral patterns from high-performing agents |
-| **Ring Leader** | Orchestrator that plans task graphs and coordinates execution |
-| **Karma** | Compounding IP moat from accumulated evolution |
+| **Execution** | A run of an objective -- spawns bots, dispatches tasks, collects results |
+| **Bot** | An AI agent running on a GCE VM with OpenClaw |
+| **Soul / SOUL.md** | Behavioral constitution (system prompt) with 7 personality dimensions |
+| **Archetype** | One of 6 canonical seed souls (Cautious Verifier, Aggressive Executor, etc.) |
+| **Council** | 3 LLM judges (Performance Judge, Soul Analyst, Devil's Advocate) that evaluate agents |
+| **God Layer** | Post-council pipeline: class transitions, DNA capture, mutation prep |
+| **Agent Class** | Progression tiers: Novice -> Understudy -> Artisan -> Retired |
+| **DNA Store** | Captured behavioral patterns from high-performing agents per task category |
+| **Skill** | Composable procedural knowledge unit (SKILL.md) equipped on agents |
+| **Karpathy Loop** | Autonomous feedback engine: mutate -> execute -> evaluate -> keep/discard -> capture DNA -> repeat |
+| **Ring Leader** | Orchestrator agent that plans task graphs and coordinates execution |
+| **Indra** | The CEO agent -- Chief of Staff that orchestrates the fleet |
+| **Tool Nexus** | Unified gateway for external tool invocations (HubSpot, Slack, Stripe, etc.) |
+| **Karma** | Compounding IP moat from accumulated agent evolution and learning |
 
-See [AGENTS.md](AGENTS.md) for the full agent reference and [docs/domain-model.md](docs/domain-model.md) for the domain model.
+See [AGENTS.md](AGENTS.md) for agent roles and evaluation, and [docs/domain-model.md](docs/domain-model.md) for the full domain model.
 
 ## Monetization
 
@@ -96,7 +124,7 @@ Pure token arbitrage: users set a daily budget, agents consume LLM tokens, Akasa
 
 | Layer | Technology |
 |-------|-----------|
-| Backend | Fastify v5 + TypeBox, Paperclip Express |
+| Backend | Fastify v5 + TypeBox |
 | Frontend | SvelteKit v2 + Svelte 5 runes |
 | ORM | Drizzle ORM + node-postgres |
 | Database | PostgreSQL + pgvector |
@@ -106,12 +134,21 @@ Pure token arbitrage: users set a daily budget, agents consume LLM tokens, Akasa
 | Auth | BetterAuth (Google OAuth) |
 | Infra | Railway (app services) + GCP (database, bot VMs) |
 
+## Testing
+
+```bash
+# Run unit tests (Vitest)
+pnpm --filter @claw/execution-service exec vitest run
+```
+
+Tests are in `src/__tests__/` and `src/services/__tests__/`. E2E tests require running services.
+
 ## Documentation
 
 | Document | Description |
 |----------|-------------|
 | [AGENTS.md](AGENTS.md) | Agent roles, classes, evaluation system |
-| [CLAUDE.md](CLAUDE.md) | AI coding assistant instructions |
+| [CLAUDE.md](CLAUDE.md) | AI coding assistant context and conventions |
 | [docs/architecture.md](docs/architecture.md) | System architecture and data flows |
 | [docs/domain-model.md](docs/domain-model.md) | Domain entities and relationships |
 | [docs/conventions.md](docs/conventions.md) | Coding conventions and standards |
@@ -121,8 +158,8 @@ Pure token arbitrage: users set a daily budget, agents consume LLM tokens, Akasa
 ## Contributing
 
 1. Create a feature branch from `main`
-2. Follow the conventions in [docs/conventions.md](docs/conventions.md)
-3. Use the PR template when opening a pull request
+2. Follow the conventions in [docs/conventions.md](docs/conventions.md) and [CLAUDE.md](CLAUDE.md)
+3. Run tests before opening a PR
 4. All PRs require review before merging
 
 ## License


### PR DESCRIPTION
## Summary
- Reflects actual service layout: adds `execution-service` alongside `akasa-server` with a dedicated Services table describing each service
- Adds missing domain concepts to the glossary: Skills, Karpathy Loop, Indra, Tool Nexus, Archetypes
- Fixes Node.js version requirement (20+ per `package.json` engines, was incorrectly listed as 22+)
- Adds Testing section with Vitest command
- Adds pnpm 10.x dev environment note and links to local-dev runbook
- Removes stale "Paperclip Express" from tech stack, corrects architecture description
- Keeps README concise and links to CLAUDE.md and docs/ for deeper detail

Closes #30

## Test plan
- [ ] Verify all doc links resolve (`AGENTS.md`, `docs/architecture.md`, `docs/domain-model.md`, `docs/conventions.md`, `docs/adr/`, `docs/runbooks/`, `docs/runbooks/local-dev.md`)
- [ ] Confirm services listed match `services/` directory contents
- [ ] Review glossary entries against `CLAUDE.md` domain glossary for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)