### PR TITLE
docs: Create API documentation for execution-service and akasa-server routes

### DIFF
--- a/docs/api-akasa-server.md
+++ b/docs/api-akasa-server.md
@@ -1,0 +1,1262 @@
+# Akasa Server API Reference
+
+The Akasa server handles evolution-specific product logic: council verdicts, God Layer, soul management, skill system, Tool Nexus connections, webhooks, Akashic Library marketplace, and the evolution dashboard.
+
+**Framework:** Express.js (mounted alongside Paperclip's Express server)
+
+**Base URL:** All routes are prefixed with `/api/akasa/`
+
+**Authentication:** Most routes expect a `userId` parameter (query or body). Internal endpoints at `/akasa/internal/*` have no auth and rely on localhost-only access.
+
+---
+
+## Health Check
+
+### `GET /api/akasa/health`
+
+Basic health check for Akasa routes.
+
+**Response 200:**
+```json
+{ "status": "ok", "service": "akasa", "timestamp": "ISO 8601" }
+```
+
+---
+
+## Council Verdicts
+
+Prefix: `/api/akasa/verdicts`
+
+### `GET /api/akasa/verdicts`
+
+List verdicts for a given execution.
+
+**Query:** `executionId` (uuid, required)
+
+**Response 200:** Array of full verdict objects ordered by creation date desc
+**Response 400:** Missing executionId
+
+---
+
+### `GET /api/akasa/verdicts/:id`
+
+Get a single verdict by UUID.
+
+**Response 200:** Full verdict object
+**Response 404:** Verdict not found
+
+---
+
+## God Layer (Verdict Actions)
+
+Prefix: `/api/akasa/verdicts`
+
+### `PATCH /api/akasa/verdicts/:id/confirm`
+
+Confirm a pending verdict and trigger the God Layer pipeline.
+
+**Request Body:**
+```json
+{ "confirmedBy": "string (optional, defaults to 'system')" }
+```
+
+**Response 200:**
+```json
+{ "confirmed": true, "godLayerResult": { ... } }
+```
+
+**Response 404:** Verdict not found
+**Response 409:** Verdict already processed
+
+---
+
+### `PATCH /api/akasa/verdicts/:id/reject`
+
+Reject a pending verdict. No God Layer triggered.
+
+**Request Body:**
+```json
+{ "confirmedBy": "string (optional)" }
+```
+
+**Response 200:** `{ "rejected": true }`
+**Response 404:** Verdict not found
+**Response 409:** Verdict already processed
+
+---
+
+### `POST /api/akasa/verdicts/batch`
+
+Batch confirm or reject multiple pending verdicts.
+
+**Request Body:**
+```json
+{
+  "verdictIds": ["uuid", "uuid"],
+  "action": "confirm | reject",
+  "userId": "string",
+  "timeOnScreenMs": 5000
+}
+```
+
+**Response 200:**
+```json
+{
+  "processed": [
+    { "id": "uuid", "success": true, "action": "confirmed" },
+    { "id": "uuid", "success": false, "error": "Verdict not found" }
+  ],
+  "summary": { "total": 2, "succeeded": 1, "failed": 1 }
+}
+```
+
+---
+
+## Evolution Trigger
+
+Prefix: `/api/akasa/evolution`
+
+### `POST /api/akasa/evolution/trigger`
+
+Manually trigger a council evaluation check cycle. Polls Paperclip's `heartbeat_runs` table for completed runs linked to Akasa bots that have no verdict yet.
+
+**Response 200:**
+```json
+{ "triggered": 3 }
+```
+
+---
+
+## Evolution Dashboard
+
+Prefix: `/api/akasa/evolution`
+
+### `GET /api/akasa/evolution/fleet`
+
+Fleet overview with class counts, score history, average composite score, and pending verdict count.
+
+**Response 200:**
+```json
+{
+  "classCounts": { "Novice": 10, "Understudy": 5, "Artisan": 2, "Retired": 1 },
+  "totalBots": 18,
+  "averageCompositeScore": "0.75",
+  "pendingVerdictCount": 3,
+  "scoreHistory": [
+    { "date": "2026-04-01", "score": "0.72" }
+  ]
+}
+```
+
+---
+
+### `GET /api/akasa/evolution/fleet/events`
+
+Chronological feed of fleet events (verdicts, class transitions, DNA captures, pioneers).
+
+**Query:**
+- `limit` (integer, max: 100, default: 50)
+- `types` (comma-separated: `verdict,class_transition,dna_capture,pioneer`)
+
+**Response 200:** Array of event objects sorted by timestamp desc
+
+---
+
+### `GET /api/akasa/evolution/agents`
+
+Agent list with current class, composite score, pioneer status, and last verdict date.
+
+**Response 200:** Array of agent objects
+
+---
+
+### `GET /api/akasa/evolution/bots/:botId/profile`
+
+Full bot profile with soul dimensions, class history, pioneer status, and archetype.
+
+**Response 200:**
+```json
+{
+  "botId": "uuid",
+  "compositeScore": "0.85",
+  "status": "idle",
+  "currentClass": "Understudy",
+  "isPioneer": false,
+  "taskCategory": "lead-generation",
+  "archetypeName": "Aggressive Executor",
+  "soulId": "uuid",
+  "soulContent": "string",
+  "dimensions": {},
+  "constitutionDirectives": [],
+  "generation": 2,
+  "classHistory": [
+    { "class": "Novice", "transitionAt": "ISO 8601", "category": "lead-generation" }
+  ]
+}
+```
+
+**Response 404:** Bot not found
+
+---
+
+### `GET /api/akasa/evolution/bots/:botId/timeline`
+
+Merged timeline of verdict, class transition, and DNA capture events for a bot.
+
+**Response 200:** Array of typed event objects sorted by timestamp desc
+
+---
+
+### `GET /api/akasa/evolution/bots/:botId/lineage`
+
+Soul ancestry chain (root-first, max depth 10).
+
+**Response 200:**
+```json
+[
+  {
+    "id": "uuid",
+    "label": "Cautious Verifier",
+    "generation": 0,
+    "isArchetype": true,
+    "isPioneer": false,
+    "parentSoulId": null
+  },
+  {
+    "id": "uuid",
+    "label": "a1b2c3d4",
+    "generation": 1,
+    "isArchetype": false,
+    "isPioneer": false,
+    "parentSoulId": "uuid"
+  }
+]
+```
+
+---
+
+### `GET /api/akasa/evolution/bots/:botId/ledger`
+
+Run-by-run experiment ledger with score delta and keep/discard decision.
+
+**Response 200:**
+```json
+[
+  {
+    "executionId": "uuid",
+    "executionDate": "ISO 8601",
+    "compositeScore": "0.85",
+    "scoreDelta": "0.05",
+    "verdictType": "Promote",
+    "status": "confirmed",
+    "keepDiscard": "keep",
+    "mutationApplied": true,
+    "soulId": "uuid"
+  }
+]
+```
+
+---
+
+### `GET /api/akasa/evolution/bots/:botId/runtime`
+
+Token consumption, cost, and budget utilization from Paperclip shared DB.
+
+**Response 200:**
+```json
+{
+  "sessionId": "uuid | null",
+  "lastRunStatus": "string | null",
+  "totalInputTokens": 50000,
+  "totalOutputTokens": 15000,
+  "totalCachedInputTokens": 10000,
+  "totalCostCents": 250,
+  "budgetMonthlyCents": 10000,
+  "spentMonthlyCents": 2500,
+  "budgetUtilization": 25,
+  "lastError": "string | null",
+  "updatedAt": "ISO 8601"
+}
+```
+
+Returns `null` if no Paperclip agent is linked to this bot.
+
+---
+
+### `GET /api/akasa/evolution/org`
+
+Hierarchical fleet tree for D3 visualization (fleet -> category -> class_tier -> agent).
+
+**Response 200:**
+```json
+{
+  "id": "fleet",
+  "label": "Fleet",
+  "type": "fleet",
+  "children": [
+    {
+      "id": "category:lead-generation",
+      "label": "lead-generation",
+      "type": "category",
+      "children": [
+        {
+          "id": "class:lead-generation:Artisan",
+          "label": "Artisan",
+          "type": "class_tier",
+          "children": [
+            { "id": "agent:uuid", "label": "a1b2c3d4", "type": "agent", "botId": "uuid", "currentClass": "Artisan", "compositeScore": "0.92", "status": "idle" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+### `GET /api/akasa/evolution/benchmarks`
+
+All category benchmarks with thin data flag and benchmark maturity status.
+
+**Response 200:** Array of category benchmark objects
+
+---
+
+### `GET /api/akasa/evolution/pending`
+
+Pending verdicts that require human confirmation (subset of all pending verdicts).
+
+**Response 200:** Array of verdict objects with full judge outputs
+
+---
+
+### `GET /api/akasa/evolution/delegations`
+
+Delegation chains from task assignments, grouped by execution.
+
+**Query:**
+- `executionId` (uuid, optional)
+- `from` (ISO date, optional)
+- `to` (ISO date, optional)
+
+**Response 200:**
+```json
+{
+  "chains": [
+    {
+      "executionId": "uuid",
+      "objective": "string",
+      "delegations": [
+        {
+          "taskId": "uuid",
+          "description": "string",
+          "status": "completed",
+          "assignedBotId": "uuid",
+          "botTier": "string",
+          "botCompositeScore": "0.85",
+          "ringLeaderTaskId": "string | null",
+          "createdAt": "ISO 8601"
+        }
+      ]
+    }
+  ],
+  "stats": {
+    "totalDelegations": 50,
+    "successRate": 85,
+    "avgDepth": 5.2,
+    "executionCount": 3
+  }
+}
+```
+
+---
+
+## Akashic Library (Marketplace)
+
+Prefix: `/api/akasa/akashic`
+
+### `GET /api/akasa/akashic/browse`
+
+Browse published DNA entries in the Akashic Library marketplace.
+
+**Query:**
+- `taskCategory` (string, optional)
+- `minScore` (number, optional)
+- `sortBy` (`score` | `generation` | `acquiredCount`, default: score)
+- `page` (integer, default: 1)
+
+**Response 200:**
+```json
+{
+  "entries": [
+    {
+      "id": "uuid",
+      "title": "string",
+      "description": "string",
+      "compositeScore": 0.92,
+      "objectiveCategory": "string",
+      "generation": 3,
+      "mutationLineageDepth": 2,
+      "taskCategory": "string",
+      "acquiredCount": 5,
+      "capturedAt": "ISO 8601"
+    }
+  ],
+  "total": 50,
+  "page": 1,
+  "pageSize": 20,
+  "totalPages": 3
+}
+```
+
+---
+
+### `POST /api/akasa/akashic/:dnaId/publish`
+
+Publish a DNA entry to the Akashic Library. Only Artisan-class agents can publish.
+
+**Request Body:**
+```json
+{
+  "title": "string",
+  "description": "string"
+}
+```
+
+**Response 200:** `{ "published": true }`
+**Response 403:** Only Artisan-class agents can publish
+**Response 404:** DNA entry not found
+
+---
+
+### `DELETE /api/akasa/akashic/:dnaId/unpublish`
+
+Unpublish a DNA entry from the marketplace.
+
+**Response 200:** `{ "unpublished": true }`
+**Response 400:** Not currently published
+**Response 404:** DNA entry not found
+
+---
+
+### `POST /api/akasa/akashic/:dnaId/acquire`
+
+Acquire a published DNA entry, generating a mutated soul and injecting it into an agent.
+
+**Request Body:**
+```json
+{
+  "agentId": "string",
+  "companyId": "string",
+  "adapterType": "string (optional)"
+}
+```
+
+**Response 201:**
+```json
+{
+  "acquired": true,
+  "newSoulId": "uuid",
+  "generation": 4
+}
+```
+
+---
+
+## Souls (Akasa Server)
+
+Prefix: `/api/akasa/souls`
+
+### `GET /api/akasa/souls`
+
+List all non-archetype souls.
+
+**Response 200:** Array of soul objects
+
+---
+
+### `GET /api/akasa/souls/:id`
+
+Get a single soul by UUID.
+
+**Response 200:** Full soul object
+**Response 404:** Soul not found
+
+---
+
+### `GET /api/akasa/souls/search`
+
+Find top-N similar souls by cosine similarity using pgvector embeddings.
+
+**Query:**
+- `query` (string, required)
+- `limit` (integer, max: 100, default: 10)
+
+**Response 200:** Array of soul objects with `similarity_score`
+
+---
+
+### `POST /api/akasa/souls/generate`
+
+Generate a new soul from an archetype.
+
+**Request Body:**
+```json
+{
+  "archetypeName": "Cautious Verifier",
+  "taskCategory": "lead-generation",
+  "botId": "uuid (optional)",
+  "executionId": "uuid (optional)"
+}
+```
+
+**Response 201:** Generated soul object
+
+---
+
+### `POST /api/akasa/souls/:id/mutate`
+
+Generate a mutated child soul from a parent soul.
+
+**Request Body:**
+```json
+{ "mutationStrength": 0.2 }
+```
+
+**Response 201:** Mutated soul object
+**Response 404:** Parent soul not found
+
+---
+
+### `POST /api/akasa/souls/inject`
+
+Inject a soul into a Paperclip agent.
+
+**Request Body:**
+```json
+{
+  "agentId": "string",
+  "companyId": "string",
+  "soulId": "uuid",
+  "adapterType": "string (optional)"
+}
+```
+
+**Response 200:** `{ "injected": true }`
+**Response 404:** Soul not found
+
+---
+
+## Tool Connections
+
+Prefix: `/api/akasa/tool-connections`
+
+### `GET /api/akasa/tool-connections`
+
+List all tool connections for a user. Encrypted credential fields are stripped from the response.
+
+**Query:** `userId` (string, required)
+
+**Response 200:** Array of connection objects (without encrypted fields)
+
+---
+
+### `POST /api/akasa/tool-connections`
+
+Create a new tool connection (OAuth or API key). Credentials are encrypted with AES-256-GCM before storage.
+
+**Request Body:**
+```json
+{
+  "userId": "string",
+  "toolId": "string",
+  "connectionType": "oauth | api_key",
+  "accessToken": "string (required for oauth)",
+  "refreshToken": "string (optional)",
+  "apiKey": "string (required for api_key)",
+  "displayLabel": "string (optional)",
+  "tokenExpiresAt": "ISO 8601 (optional)",
+  "scopes": "string (optional)"
+}
+```
+
+**Response 201:** Created connection (without encrypted fields)
+**Response 400:** Missing required fields
+**Response 409:** Connection already exists for this user/tool
+
+---
+
+### `DELETE /api/akasa/tool-connections/:id`
+
+Delete a tool connection.
+
+**Response 200:** `{ "ok": true }`
+**Response 404:** Connection not found
+
+---
+
+### `PATCH /api/akasa/tool-connections/:id/refresh`
+
+Update OAuth tokens after a refresh.
+
+**Request Body:**
+```json
+{
+  "accessToken": "string (required)",
+  "refreshToken": "string (optional)",
+  "tokenExpiresAt": "ISO 8601 (optional)"
+}
+```
+
+**Response 200:** Updated connection (without encrypted fields)
+
+---
+
+### `POST /api/akasa/tool-connections/:id/test`
+
+Test a connection by verifying credential decryption.
+
+**Response 200:**
+```json
+{ "success": true, "toolId": "hubspot", "connectionType": "oauth" }
+```
+
+Or on failure:
+```json
+{ "success": false, "error": "Credential decryption failed" }
+```
+
+---
+
+### `GET /api/akasa/tool-connections/:id/logs`
+
+Get invocation logs for a specific connection (last 100 entries).
+
+**Response 200:** Array of invocation log objects
+
+---
+
+## OAuth Flow
+
+Prefix: `/api/akasa/tool-connections`
+
+### `GET /api/akasa/tool-connections/oauth/:toolId/start`
+
+Redirect user to the OAuth provider's authorization page.
+
+**Query:**
+- `userId` (string, required)
+- `redirectUri` (string, optional)
+
+**Response 302:** Redirect to provider authorization URL
+
+---
+
+### `GET /api/akasa/tool-connections/oauth/:toolId/callback`
+
+OAuth callback handler. Exchanges authorization code for tokens, encrypts and persists the connection.
+
+**Query:**
+- `code` (string, required)
+- `state` (base64url-encoded JSON, required)
+
+**Response 302:** Redirect to success page (`/tools?connected=<toolId>`)
+
+---
+
+## Webhooks
+
+Prefix: `/api/akasa/webhooks`
+
+### `POST /api/akasa/webhooks/generate-url`
+
+Generate a unique webhook URL for a tool connection.
+
+**Request Body:**
+```json
+{ "connectionId": "uuid" }
+```
+
+**Response 200:**
+```json
+{
+  "webhookUrl": "/api/akasa/webhooks/hubspot/<token>",
+  "token": "string",
+  "toolId": "hubspot"
+}
+```
+
+---
+
+### `POST /api/akasa/webhooks/:toolId/:token`
+
+Receive an incoming webhook. Validates signature (HubSpot, Slack, Stripe, GitHub, Linear), logs the receipt, evaluates routing rules, and dispatches to the matched agent.
+
+**Response 200:** `{ "received": true }`
+**Response 401:** Invalid token or signature
+
+---
+
+### `POST /api/akasa/webhooks/:toolId/simulate`
+
+Dry-run webhook routing rule evaluation.
+
+**Request Body:**
+```json
+{
+  "userId": "string",
+  "eventType": "string",
+  "payload": {}
+}
+```
+
+**Response 200:**
+```json
+{
+  "matched": true,
+  "eventType": "contact.creation",
+  "toolId": "hubspot",
+  "matchedRule": { "id": "uuid", "eventType": "contact.creation", "assignToAgentId": "uuid" },
+  "agentId": "uuid",
+  "dryRun": true
+}
+```
+
+---
+
+### `GET /api/akasa/webhooks/logs`
+
+Aggregated webhook event log for a user.
+
+**Query:** `userId` (string, required)
+
+**Response 200:** Array of webhook-prefixed invocation log objects (last 100)
+
+---
+
+## Webhook Routing Rules
+
+Prefix: `/api/akasa/webhook-routing-rules`
+
+### `GET /api/akasa/webhook-routing-rules`
+
+List all routing rules for a user.
+
+**Query:** `userId` (string, required)
+
+**Response 200:** Array of routing rule objects
+
+---
+
+### `POST /api/akasa/webhook-routing-rules`
+
+Create a new routing rule.
+
+**Request Body:**
+```json
+{
+  "userId": "string",
+  "connectionId": "uuid",
+  "toolId": "string",
+  "eventType": "string (or '*' for wildcard)",
+  "condition": "string (optional)",
+  "assignToAgentId": "uuid (optional)"
+}
+```
+
+**Response 201:** Created routing rule object
+
+---
+
+### `DELETE /api/akasa/webhook-routing-rules/:id`
+
+Delete a routing rule.
+
+**Response 204:** No content
+**Response 404:** Rule not found
+
+---
+
+## Commands
+
+Prefix: `/api/akasa/commands`
+
+### `POST /api/akasa/commands/execute`
+
+Execute a quick command for fleet management.
+
+**Request Body:**
+```json
+{
+  "command": "status | pause | resume | assign",
+  "args": ["agentName", "issueId"],
+  "companyId": "uuid"
+}
+```
+
+**Response 200:**
+```json
+{
+  "ok": true,
+  "message": "Fleet status: 3 active bots, 1 running execution, 2 pending verdicts.",
+  "data": { "activeBots": 3, "runningExecutions": 1, "pendingVerdicts": 2 }
+}
+```
+
+---
+
+## Settings
+
+Prefix: `/api/akasa/settings`
+
+### `GET /api/akasa/settings/profile`
+
+Get the current user's profile.
+
+**Response 200:**
+```json
+{ "id": "uuid", "name": "string", "email": "string", "image": "string | null" }
+```
+
+---
+
+### `GET /api/akasa/settings/preferences`
+
+Get notification preferences for the current user.
+
+**Response 200:** Preferences object with email/in-app toggle booleans
+
+---
+
+### `PUT /api/akasa/settings/preferences`
+
+Create or update notification preferences.
+
+**Request Body:**
+```json
+{
+  "emailEvolutionEvents": true,
+  "emailBudgetAlerts": true,
+  "emailSkillEvents": true,
+  "inAppEvolutionEvents": true,
+  "inAppBudgetAlerts": true,
+  "inAppSkillEvents": true,
+  "budgetAlertThreshold50": true,
+  "budgetAlertThreshold75": true,
+  "budgetAlertThreshold90": true
+}
+```
+
+**Response 200:** Updated preferences object
+
+---
+
+### `GET /api/akasa/settings/api-keys`
+
+List active (non-revoked) API keys for the current user.
+
+**Response 200:** Array of API key objects (no raw key, only prefix)
+
+---
+
+### `POST /api/akasa/settings/api-keys`
+
+Create a new API key. The raw key is returned only once in the response.
+
+**Request Body:**
+```json
+{ "name": "string" }
+```
+
+**Response 201:**
+```json
+{
+  "id": "string",
+  "key": "aka_<hex>",
+  "keyPrefix": "aka_1234",
+  "name": "string",
+  "createdAt": "ISO 8601"
+}
+```
+
+---
+
+### `DELETE /api/akasa/settings/api-keys/:id`
+
+Revoke an API key (soft delete via `revokedAt` timestamp).
+
+**Response 204:** No content
+
+---
+
+### `DELETE /api/akasa/settings/account`
+
+Delete the current user's account.
+
+**Response 204:** No content
+
+---
+
+## Skills
+
+Prefix: `/api/akasa/skills`
+
+### `GET /api/akasa/skills`
+
+List all skills for a user with optional category/source filtering.
+
+**Query:**
+- `userId` (string, required)
+- `category` (string, optional)
+- `source` (string, optional)
+
+**Response 200:** Array of skill objects
+
+---
+
+### `POST /api/akasa/skills`
+
+Create a new skill from SKILL.md content. Validates frontmatter, progressive disclosure structure, and trigger patterns.
+
+**Request Body:**
+```json
+{
+  "userId": "string",
+  "content": "--- SKILL.md content ---",
+  "source": "user_created | imported | curated (optional)",
+  "isPublic": false
+}
+```
+
+**Response 201:** Created skill object
+**Response 400:** Validation errors array
+**Response 409:** Skill name already exists
+
+---
+
+### `GET /api/akasa/skills/:id`
+
+Get a single skill by ID.
+
+**Response 200:** Full skill object
+**Response 404:** Skill not found
+
+---
+
+### `PATCH /api/akasa/skills/:id`
+
+Update a skill's content, name, or description.
+
+**Request Body:** `{ "content": "string", "name": "string", "description": "string" }` (at least one required)
+
+**Response 200:** Updated skill object
+**Response 400:** Validation errors
+**Response 404:** Skill not found
+
+---
+
+### `DELETE /api/akasa/skills/:id`
+
+Delete a skill.
+
+**Response 200:** `{ "ok": true }`
+**Response 404:** Skill not found
+
+---
+
+## Agent Skills (Loadout)
+
+Prefix: `/api/akasa/agents`
+
+### `GET /api/akasa/agents/:agentId/skills`
+
+List all equipped skills for an agent.
+
+**Response 200:**
+```json
+[
+  {
+    "skillId": "uuid",
+    "equippedAt": "ISO 8601",
+    "equippedBy": "string",
+    "skillName": "string",
+    "skillDescription": "string",
+    "skillCategory": "string",
+    "skillVersion": "1.0.0"
+  }
+]
+```
+
+---
+
+### `POST /api/akasa/agents/:agentId/skills/:skillId`
+
+Equip a skill to an agent. Checks agent class capacity limits (Novice: 3, Understudy: 5, Artisan: 8).
+
+**Request Body:**
+```json
+{ "equippedBy": "string" }
+```
+
+**Response 201:** Equipped skill record
+**Response 400:** Capacity exceeded
+**Response 404:** Skill or agent class not found
+**Response 409:** Skill already equipped
+
+---
+
+### `DELETE /api/akasa/agents/:agentId/skills/:skillId`
+
+Unequip a skill from an agent.
+
+**Response 200:** `{ "ok": true }`
+**Response 404:** Equipped skill not found
+
+---
+
+## Tool Registry (OpenAPI Import)
+
+Prefix: `/api/akasa/tool-registry`
+
+### `POST /api/akasa/tool-registry/preview`
+
+Parse an OpenAPI/Swagger spec and return discovered endpoints without persisting.
+
+**Request Body:**
+```json
+{
+  "specUrl": "string (URL to spec)",
+  "specJson": {}
+}
+```
+
+One of `specUrl` or `specJson` is required.
+
+**Response 200:** Parsed spec with discovered endpoints
+**Response 422:** Failed to parse spec
+
+---
+
+### `POST /api/akasa/tool-registry/import`
+
+Import selected endpoints from an OpenAPI spec.
+
+**Request Body:**
+```json
+{
+  "userId": "string",
+  "specUrl": "string (optional)",
+  "specJson": {},
+  "selectedEndpoints": [{ "method": "GET", "path": "/users" }]
+}
+```
+
+**Response 201:** Imported endpoint records
+**Response 422:** Import failed
+
+---
+
+### `GET /api/akasa/tool-registry`
+
+List all imported tool endpoints for a user.
+
+**Query:** `userId` (string, required)
+
+**Response 200:** Array of registry entry objects
+
+---
+
+### `DELETE /api/akasa/tool-registry/:specId`
+
+Remove all endpoints from a specific import.
+
+**Query:** `userId` (string, required)
+
+**Response 200:** `{ "deleted": 5 }`
+
+---
+
+### `PATCH /api/akasa/tool-registry/:id/toggle`
+
+Enable or disable a specific endpoint.
+
+**Request Body:**
+```json
+{ "userId": "string", "isEnabled": true }
+```
+
+**Response 200:** Updated registry entry
+**Response 404:** Entry not found
+
+---
+
+## Marketplace Reviews
+
+Prefix: `/api/akasa/reviews`
+
+### `POST /api/akasa/reviews`
+
+Submit or update a review (one per user per target, upsert behavior).
+
+**Request Body:**
+```json
+{
+  "userId": "string",
+  "targetId": "uuid",
+  "targetType": "soul | skill",
+  "rating": 5,
+  "reviewText": "string (optional)"
+}
+```
+
+**Response 201:** Created review (or 200 if updated)
+**Response 400:** Invalid rating or missing fields
+
+---
+
+### `GET /api/akasa/reviews`
+
+List reviews for a target.
+
+**Query:**
+- `targetId` (string, required)
+- `targetType` (`soul` | `skill`, optional)
+
+**Response 200:** Array of review objects
+
+---
+
+### `GET /api/akasa/reviews/summary`
+
+Average rating and count for a target.
+
+**Query:** `targetId` (string, required)
+
+**Response 200:**
+```json
+{ "targetId": "uuid", "avgRating": 4.5, "count": 12 }
+```
+
+---
+
+### `DELETE /api/akasa/reviews/:id`
+
+Delete own review.
+
+**Query:** `userId` (string, required -- must match review owner)
+
+**Response 200:** `{ "deleted": true }`
+**Response 403:** Can only delete own reviews
+**Response 404:** Review not found
+
+---
+
+## GitHub Integration
+
+Prefix: `/api/akasa/github`
+
+These routes use the user's GitHub OAuth connection from tool_connections.
+
+### `GET /api/akasa/github/repos`
+
+List authenticated user's GitHub repositories.
+
+**Query:** `userId` (string, required)
+
+**Response 200:** Array of repo objects with `name`, `fullName`, `owner`, `isPrivate`, `cloneUrl`, `defaultBranch`
+
+---
+
+### `GET /api/akasa/github/repos/:owner/:repo`
+
+Get details for a specific repository.
+
+**Query:** `userId` (string, required)
+
+**Response 200:** Repo detail object
+
+---
+
+### `GET /api/akasa/github/repos/:owner/:repo/branches`
+
+List branches for a repository.
+
+**Query:** `userId` (string, required)
+
+**Response 200:** Array of branch objects with `name`, `sha`, `isProtected`
+
+---
+
+## Internal Endpoints
+
+Prefix: `/api/akasa/internal`
+
+**WARNING:** No authentication -- relies on localhost-only access. Never expose on a public interface.
+
+### `GET /api/akasa/internal/user-by-company/:companyId`
+
+Translate a Paperclip company ID to a BetterAuth user ID.
+
+**Response 200:** `{ "userId": "string" }`
+**Response 404:** No user found
+
+---
+
+### `GET /api/akasa/internal/tool-credential/:userId/:toolId`
+
+Resolve a valid tool credential (handles token refresh transparently).
+
+**Response 200:** `{ "token": "string", "connectionId": "uuid" }`
+**Response 404:** No connection found
+**Response 410:** Connection not active
+
+---
+
+### `POST /api/akasa/internal/log-invocation`
+
+Log a tool invocation from the plugin worker.
+
+**Request Body:**
+```json
+{
+  "toolId": "string",
+  "action": "string",
+  "agentId": "string | null",
+  "userId": "string",
+  "connectionId": "uuid",
+  "latencyMs": 150,
+  "success": true,
+  "errorMessage": "string (optional)",
+  "requestSummary": "string (optional)",
+  "responseSummary": "string (optional)"
+}
+```
+
+**Response 204:** No content
+
+---
+
+### `POST /api/akasa/internal/fleet-event`
+
+Receive fleet events from the execution-service God Layer worker for WebSocket broadcast.
+
+**Request Body:**
+```json
+{
+  "type": "string",
+  "description": "string",
+  "botId": "uuid (optional)",
+  "executionId": "uuid (optional)",
+  "soulId": "uuid (optional)",
+  "taskCategory": "string (optional)",
+  "verdictType": "string (optional)",
+  "fromClass": "string (optional)",
+  "toClass": "string (optional)",
+  "compositeScore": "string (optional)",
+  "isPioneer": false
+}
+```
+
+**Response 204:** No content
+**Response 400:** Missing required fields

--- a/docs/api-execution-service.md
+++ b/docs/api-execution-service.md
@@ -1,0 +1,1267 @@
+# Execution Service API Reference
+
+The execution service is the primary backend for Akasa. It manages bot executions, objectives, billing, metrics, souls, verdicts, and the Ring Leader orchestration layer.
+
+**Framework:** Fastify v5 with TypeBox schema validation
+
+**Base URL:** `http://localhost:3001` (local) or the deployed Railway URL
+
+## Authentication
+
+Most routes use JWT bearer token authentication via the `Authorization` header. The token is validated by `verifyAuthToken()` against the `AUTH_SECRET` environment variable.
+
+Some routes also support an internal API key bypass via the `X-Internal-Key` header (for CLI testing without a browser session). This is only active when `INTERNAL_API_KEY` is set in the environment.
+
+```
+Authorization: Bearer <jwt-token>
+X-Internal-Key: <internal-api-key>   # optional bypass
+```
+
+---
+
+## Health Check
+
+### `GET /health`
+
+Basic health check endpoint.
+
+**Response 200:**
+```json
+{ "status": "ok" }
+```
+
+---
+
+## Executions
+
+Prefix: `/executions`
+
+### `POST /executions`
+
+Create a new execution. Parses the objective into a task graph, validates pre-flight, and spawns a Ring Leader.
+
+**Auth:** Required (JWT or internal API key)
+
+**Request Body:**
+```json
+{
+  "objective": "string (required, minLength: 1)",
+  "maxBots": "integer (required, 3-20)",
+  "budgetCapCents": "integer (optional, min: 0)",
+  "runtimeLimitSeconds": "integer (optional, min: 60)",
+  "allowedTools": ["string"] ,
+  "llmProvider": "string (optional)",
+  "allowedDomains": ["string"],
+  "objectiveId": "uuid (optional)",
+  "campaignType": "'ad_hoc' | 'campaign' (optional)",
+  "projectId": "uuid (optional)",
+  "enableEvolution": "boolean (optional, enables Karpathy Loop)",
+  "maxIterations": "integer (optional, 1-50)",
+  "campaignBudgetCapCents": "integer (optional, min: 0)"
+}
+```
+
+**Response 201:**
+```json
+{
+  "executionId": "uuid",
+  "status": "pre_flight",
+  "evolutionCampaignId": "uuid (only when enableEvolution=true)"
+}
+```
+
+**Response 400:** Pre-flight validation failed or invalid input
+**Response 401:** Unauthorized
+**Response 500:** Failed to parse objective
+
+---
+
+### `GET /executions/:id`
+
+Get a single execution by ID.
+
+**Params:** `id` (uuid)
+
+**Response 200:**
+```json
+{
+  "id": "uuid",
+  "status": "pre_flight | queued | running | paused | stopped | completed | failed",
+  "objective": "string",
+  "maxBots": 5,
+  "budgetCapCents": 10000,
+  "runtimeLimitSeconds": 3600,
+  "allowedTools": ["tool-a"],
+  "llmProvider": "string | null",
+  "allowedDomains": ["string"] ,
+  "campaignType": "string | null",
+  "projectId": "uuid | null",
+  "createdAt": "ISO 8601",
+  "updatedAt": "ISO 8601"
+}
+```
+
+**Response 404:** Execution not found
+
+---
+
+### `GET /executions/all`
+
+List all executions. Optionally filter by project.
+
+**Query:** `projectId` (uuid, optional)
+
+**Response 200:**
+```json
+[
+  {
+    "id": "uuid",
+    "status": "running",
+    "objective": "string",
+    "maxBots": 5,
+    "budgetCapCents": 10000,
+    "allowedTools": [],
+    "projectId": "uuid | null",
+    "createdAt": "ISO 8601",
+    "updatedAt": "ISO 8601",
+    "activeBotCount": 3
+  }
+]
+```
+
+---
+
+### `GET /executions/:id/tasks`
+
+Get all tasks for an execution.
+
+**Params:** `id` (uuid)
+
+**Response 200:**
+```json
+[
+  {
+    "id": "uuid",
+    "executionId": "uuid",
+    "status": "pending | claimed | completed | failed",
+    "description": "string",
+    "result": "string | null",
+    "claimedByBotId": "uuid | null",
+    "attemptCount": 0,
+    "createdAt": "ISO 8601",
+    "updatedAt": "ISO 8601"
+  }
+]
+```
+
+---
+
+### `GET /executions/:id/bots`
+
+Get all bots for an execution.
+
+**Params:** `id` (uuid)
+
+**Response 200:**
+```json
+[
+  {
+    "id": "uuid",
+    "executionId": "uuid",
+    "status": "spawning | idle | working | stopping | stopped | failed",
+    "containerId": "string | null",
+    "imageTag": "string",
+    "tasksClaimed": 0,
+    "tasksCompleted": 0,
+    "tasksFailed": 0,
+    "createdAt": "ISO 8601",
+    "updatedAt": "ISO 8601"
+  }
+]
+```
+
+---
+
+### `GET /executions/:id/report`
+
+Get execution summary report with cost, performance, and soul tier distribution.
+
+**Params:** `id` (uuid)
+
+**Response 200:**
+```json
+{
+  "executionId": "uuid",
+  "totalBots": 5,
+  "totalBotHours": 2.5,
+  "totalCostCents": 500,
+  "averageBotScore": 0.85,
+  "topPerformingBotId": "uuid | null",
+  "errorDistribution": { "timeout": 2, "crash": 1 },
+  "costPerTaskCents": 50,
+  "totalTasks": 10,
+  "completedTasks": 8,
+  "failedTasks": 2,
+  "soulTierDistribution": {
+    "novice": 2,
+    "understudy": 2,
+    "artisan": 1,
+    "retired": 0
+  }
+}
+```
+
+---
+
+### `GET /executions/:id/leaderboard`
+
+Bot leaderboard sorted by composite score.
+
+**Params:** `id` (uuid)
+
+**Response 200:**
+```json
+[
+  {
+    "botId": "uuid",
+    "compositeScore": 0.92,
+    "tier": "string | null",
+    "tasksCompleted": 5,
+    "tasksFailed": 0,
+    "botHours": 1.2,
+    "agentClass": "Novice | Understudy | Artisan | Retired | null",
+    "isPioneer": false,
+    "verdictSummary": "string | null",
+    "verdictType": "string | null"
+  }
+]
+```
+
+---
+
+### `GET /executions/:id/pending-verdicts`
+
+Get pending Promote/Retire verdicts for a specific execution.
+
+**Params:** `id` (uuid)
+
+**Response 200:** Array of pending verdict objects with full council output
+
+---
+
+### `POST /executions/:id/stop`
+
+Stop a running execution and all its bots.
+
+**Params:** `id` (uuid)
+
+**Response 200:** `{ "success": true }`
+**Response 404:** Execution not found
+
+---
+
+### `POST /executions/:id/confirm`
+
+Confirm a pre-flight execution, transitioning to queued then running. Spawns agents.
+
+**Auth:** Required
+
+**Params:** `id` (uuid)
+
+**Response 200:** `{ "success": true }`
+**Response 401:** Unauthorized
+**Response 404:** Execution not found
+**Response 409:** Not in pre_flight status or manifest not assembled
+
+---
+
+### `POST /executions/:id/cancel`
+
+Cancel a pre-flight execution, transitioning to stopped.
+
+**Auth:** Required
+
+**Params:** `id` (uuid)
+
+**Response 200:** `{ "success": true }`
+**Response 401:** Unauthorized
+**Response 404:** Execution not found
+**Response 409:** Not in pre_flight status
+
+---
+
+## Execution Metrics
+
+Prefix: `/executions`
+
+### `GET /executions/:id/metrics`
+
+Live execution metrics from Redis budget keys and DB.
+
+**Params:** `id` (uuid)
+
+**Response 200:**
+```json
+{
+  "activeBotCount": 3,
+  "totalBotHours": 1.5,
+  "spentCents": 250,
+  "budgetCapCents": 1000,
+  "remainingCents": 750,
+  "estimatedCostCents": 250
+}
+```
+
+---
+
+### `GET /executions/projects/:id/metrics`
+
+Aggregate metrics for all executions in a project.
+
+**Params:** `id` (uuid -- project ID)
+
+**Response 200:**
+```json
+{
+  "totalExecutions": 5,
+  "totalBotHours": 12.3,
+  "totalSpentCents": 2500,
+  "activeBotCount": 2,
+  "completedExecutions": 3,
+  "failedExecutions": 1
+}
+```
+
+---
+
+## Execution SSE Streams
+
+Prefix: `/executions`
+
+### `GET /executions/:id/events` (SSE)
+
+Server-Sent Events stream for execution lifecycle, task lifecycle, bot lifecycle, guardrail, Ring Leader, and billing events. Creates per-connection Pub/Sub subscriptions filtered by execution ID.
+
+**Params:** `id` (uuid)
+
+**Event types:** `execution_status_changed`, `task_claimed`, `task_completed`, `bot_started`, `bot_stopped`, `guardrail_triggered`, `ring_leader_*`, `billing_*`
+
+---
+
+## Soul Lifecycle SSE
+
+Prefix: `/events`
+
+### `GET /events/lifecycle` (SSE)
+
+Global soul lifecycle SSE stream (not execution-scoped). Subscribes to the `soul-lifecycle` Pub/Sub topic.
+
+---
+
+## Bots
+
+Prefix: `/bots`
+
+### `GET /bots/by-execution/:executionId`
+
+List all bots for an execution with enriched data (agent class, current task, tool call count, token burn rate).
+
+**Response 200:**
+```json
+[
+  {
+    "id": "uuid",
+    "status": "working",
+    "tasksClaimed": 3,
+    "tasksCompleted": 2,
+    "tasksFailed": 0,
+    "startedAt": "ISO 8601 | null",
+    "errorMessage": "string | null",
+    "agentClass": "Novice | Understudy | Artisan | Retired | null",
+    "currentTaskDescription": "string | null",
+    "toolCallCount": 15,
+    "tokenBurnRate": 500
+  }
+]
+```
+
+---
+
+### `GET /bots/:botId/soul`
+
+Get soul content, lineage metadata, council verdict, and agent class for a bot.
+
+**Response 200:**
+```json
+{
+  "soulId": "uuid | null",
+  "soulContent": "string | null",
+  "generation": 2,
+  "parentSoulId": "uuid | null",
+  "isArchetype": false,
+  "taskCategory": "string | null",
+  "constitutionDirectives": ["string"],
+  "dimensions": {},
+  "agentClass": "Understudy | null",
+  "verdict": {
+    "verdictType": "Promote",
+    "weightedConfidenceScore": 0.87,
+    "verdictSummary": "string",
+    "soulAnalystOutput": {},
+    "performanceJudgeOutput": {}
+  }
+}
+```
+
+---
+
+### `GET /bots/:botId/detail`
+
+Per-bot metrics and step trace from tool invocations.
+
+**Response 200:**
+```json
+{
+  "bot": {
+    "id": "uuid",
+    "status": "working",
+    "compositeScore": 0.85,
+    "tier": "string | null",
+    "startedAt": "ISO 8601 | null",
+    "stoppedAt": "ISO 8601 | null"
+  },
+  "metrics": {
+    "botId": "uuid",
+    "tasksCompleted": 5,
+    "tasksFailed": 1,
+    "totalTasks": 6,
+    "successRate": 0.83,
+    "totalCostCents": 150,
+    "costPerTaskCents": 25,
+    "totalTokens": 50000,
+    "tokensPerTask": 8333,
+    "toolCallsPerTask": 3.5,
+    "totalToolCalls": 21,
+    "botHours": 0.5,
+    "tasksPerMinute": 0.2,
+    "totalRetries": 2,
+    "errorRate": 0.17,
+    "idleRatio": 0.1
+  },
+  "steps": [
+    {
+      "toolName": "web_search",
+      "invocationId": "uuid",
+      "rejected": false,
+      "rejectionReason": null,
+      "durationMs": 1200,
+      "promptTokens": 500,
+      "completionTokens": 200,
+      "totalTokens": 700,
+      "requestSummary": {},
+      "responseSummary": {},
+      "invokedAt": "ISO 8601"
+    }
+  ]
+}
+```
+
+---
+
+### `GET /bots/:botId/logs` (SSE)
+
+Per-bot process log SSE stream. Subscribes to bot-lifecycle, task-lifecycle, and guardrail-events Pub/Sub topics filtered by bot ID. Also polls tool_invocations every 2 seconds.
+
+---
+
+### `POST /bots/:botId/ready`
+
+Called by bot VM startup script when OpenClaw Gateway is ready. Accepts success or failure payload.
+
+**Request Body (success):**
+```json
+{
+  "success": true,
+  "internalIp": "10.0.0.5",
+  "port": 8080,
+  "gatewayToken": "string",
+  "openclawVersion": "string (optional)"
+}
+```
+
+**Request Body (failure):**
+```json
+{
+  "success": false,
+  "error": "string"
+}
+```
+
+**Response 200:** `{ "ok": true }`
+**Response 404:** Bot not found or not in registry
+**Response 409:** Bot already marked as ready
+**Response 503:** Failed to connect to OpenClaw Gateway
+
+---
+
+## Billing
+
+Prefix: `/billing`
+
+### `GET /billing/history`
+
+List all executions with rolled-up cost, bot-hours, and task count.
+
+**Response 200:**
+```json
+[
+  {
+    "executionId": "uuid",
+    "objective": "string",
+    "status": "completed",
+    "createdAt": "ISO 8601",
+    "totalCostCents": 500,
+    "totalBotHours": 2.5,
+    "taskCount": 10
+  }
+]
+```
+
+---
+
+### `GET /billing/summary`
+
+Monthly totals for the current month.
+
+**Response 200:**
+```json
+{
+  "monthlyBotHours": 15.3,
+  "monthlySpendCents": 3000,
+  "executionCount": 8
+}
+```
+
+---
+
+### `POST /billing/webhook`
+
+Handle Stripe webhooks. Validates the `stripe-signature` header.
+
+**Headers:** `stripe-signature` (required)
+
+**Response 200:** `{ "received": true }`
+**Response 400:** Missing signature or invalid signature
+
+---
+
+## Verdicts
+
+Prefix: `/verdicts`
+
+### `GET /verdicts/pending`
+
+List all pending Promote/Retire verdicts awaiting operator action.
+
+**Response 200:**
+```json
+[
+  {
+    "id": "uuid",
+    "botId": "uuid",
+    "executionId": "uuid",
+    "verdictType": "Promote",
+    "weightedConfidenceScore": 0.87,
+    "verdictSummary": "string",
+    "hasUnresolvedDevilsAdvocate": false,
+    "createdAt": "ISO 8601"
+  }
+]
+```
+
+---
+
+### `GET /verdicts/:verdictId`
+
+Get a single verdict with full evidence columns (all three judge outputs).
+
+**Response 200:** Full verdict object with `devilsAdvocateOutput`, `performanceJudgeOutput`, `soulAnalystOutput`
+**Response 404:** Verdict not found
+
+---
+
+### `POST /verdicts/:verdictId/confirm`
+
+Confirm a pending Promote/Retire verdict. Enqueues a God Layer job.
+
+**Request Body:**
+```json
+{
+  "userId": "string",
+  "timeOnScreenMs": 5000
+}
+```
+
+**Response 200:** `{ "ok": true }`
+**Response 409:** Already resolved or not eligible
+
+---
+
+### `POST /verdicts/:verdictId/reject`
+
+Reject a pending Promote/Retire verdict.
+
+**Request Body:**
+```json
+{
+  "userId": "string",
+  "timeOnScreenMs": 3000
+}
+```
+
+**Response 200:** `{ "ok": true }`
+**Response 409:** Already resolved or not eligible
+
+---
+
+### `GET /verdicts/calibration`
+
+Per-user confirmation rate with anti-rubber-stamp warning.
+
+**Query:** `userId` (string, required)
+
+**Response 200:**
+```json
+{
+  "total": 20,
+  "confirmed": 19,
+  "rate": 0.95,
+  "warningTriggered": true
+}
+```
+
+---
+
+## Army Builder
+
+Prefix: `/army-builder`
+
+### `GET /army-builder/analysis`
+
+Pre-execution composition analysis. Uses LLM to extract task categories from the objective and returns library depth and budget tier calculations.
+
+**Query:**
+- `objective` (string, required)
+- `maxBots` (integer, required, min: 1)
+
+**Response 200:**
+```json
+{
+  "categories": ["lead-generation", "content-writing"],
+  "libraryDepth": [
+    {
+      "taskCategory": "lead-generation",
+      "noviceCount": 5,
+      "understudyCount": 2,
+      "artisanCount": 1,
+      "totalAgents": 8
+    }
+  ],
+  "budgetTiers": {
+    "full": { "label": "Full crew -- 5 agents per category", "agentCount": 10, "perCategory": 5 },
+    "reduced": { "label": "75% crew -- 3 agents per category", "agentCount": 8, "perCategory": 3 },
+    "minimumViable": { "label": "Minimum viable -- 3 Novices per category", "agentCount": 6, "perCategory": 3 }
+  },
+  "blocked": false,
+  "blockReason": null
+}
+```
+
+---
+
+## Objectives
+
+Prefix: `/objectives`
+
+### `POST /objectives`
+
+Create a new objective.
+
+**Auth:** Required
+
+**Request Body:**
+```json
+{
+  "name": "string (1-255 chars)",
+  "description": "string (optional)",
+  "defaultMaxBots": 5,
+  "defaultBudgetCapCents": 10000,
+  "defaultRuntimeLimitSeconds": 3600,
+  "defaultAllowedTools": ["tool-a"],
+  "projectId": "uuid (optional)"
+}
+```
+
+**Response 201:** Objective object
+**Response 400:** Validation error
+**Response 401:** Unauthorized
+
+---
+
+### `GET /objectives`
+
+List objectives with aggregation (last run status, run count, total spend, best bot class).
+
+**Query:**
+- `archived` (string, optional -- `"true"` to show archived)
+- `projectId` (uuid, optional)
+
+**Response 200:** Array of objective objects with aggregation fields
+
+---
+
+### `GET /objectives/:id`
+
+Get a single objective by ID.
+
+**Response 200:** Objective object
+**Response 404:** Not found
+
+---
+
+### `PATCH /objectives/:id`
+
+Update or archive an objective. All fields are optional.
+
+**Auth:** Required
+
+**Request Body:** Partial objective fields
+
+**Response 200:** Updated objective
+**Response 404:** Not found
+
+---
+
+### `DELETE /objectives/:id`
+
+Delete an objective. Linked executions get `objective_id` set to NULL.
+
+**Auth:** Required
+
+**Response 200:** `{ "success": true }`
+**Response 404:** Not found
+
+---
+
+### `GET /objectives/:id/executions`
+
+List all runs for an objective with cost and score aggregations.
+
+**Response 200:** Array of execution objects with `totalCostCents`, `botCount`, `avgCompositeScore`
+
+---
+
+### `GET /objectives/:id/stats`
+
+Aggregate stats for an objective (spend, tasks, bot-hours, class breakdown).
+
+**Response 200:**
+```json
+{
+  "totalSpendCents": 5000,
+  "totalTasksCompleted": 50,
+  "totalBotHours": 25.5,
+  "runCount": 5,
+  "classBreakdown": { "novice": 10, "understudy": 5, "artisan": 2, "retired": 1 },
+  "classTrendSummary": "2 Artisans, 5 Understudys, 10 Novices across 5 runs"
+}
+```
+
+---
+
+### `GET /objectives/:id/timeline`
+
+DNA evolution timeline events for an objective. Merges council verdicts and pioneer benchmark events.
+
+**Query:**
+- `limit` (integer, 1-100, default: 20)
+- `offset` (integer, min: 0)
+- `filter` (string: `all`, `promote`, `demote`, `retire`, `monitor_maintain`, `pioneer`)
+
+**Response 200:**
+```json
+{
+  "events": [
+    {
+      "id": "uuid",
+      "eventType": "Promote | Demote | Retire | Monitor | Maintain | Pioneer",
+      "botId": "uuid",
+      "executionId": "uuid",
+      "runNumber": 3,
+      "taskCategory": "string | null",
+      "fromClass": "Novice | null",
+      "toClass": "Understudy | null",
+      "weightedConfidenceScore": 0.87,
+      "compositeScore": 0.85,
+      "verdictSummary": "string",
+      "hasMutationLineage": true,
+      "isPioneer": false,
+      "occurredAt": "ISO 8601"
+    }
+  ],
+  "total": 15,
+  "hasMore": false
+}
+```
+
+---
+
+## Ring Leader
+
+Prefix: `/ring-leader`
+
+### `GET /ring-leader/runs/:runId/manifest`
+
+Get the full population manifest for a Ring Leader run.
+
+**Response 200:**
+```json
+{
+  "runId": "uuid",
+  "executionId": "uuid",
+  "status": "string",
+  "manifests": [
+    {
+      "taskId": "string",
+      "taskDescription": "string",
+      "assignedSouls": [
+        {
+          "soulId": "uuid",
+          "agentClass": "Artisan | Understudy | Novice",
+          "source": "library | generated | mutated",
+          "parentSoulId": "uuid | null",
+          "mutationApplied": "string | null",
+          "selectionRationale": "string",
+          "differentiationScore": 0.85
+        }
+      ],
+      "pioneerFlag": false,
+      "varianceIntent": "string | null"
+    }
+  ],
+  "missionBrief": {}
+}
+```
+
+---
+
+### `GET /ring-leader/runs/by-execution/:executionId`
+
+Look up a Ring Leader run by execution ID.
+
+**Response 200:** Same as manifest response above
+**Response 404:** Not found
+
+---
+
+### `GET /ring-leader/runs/by-execution/:executionId/state`
+
+Get live run state including budget, task states, drift score, and anomalies.
+
+**Response 200:**
+```json
+{
+  "runId": "uuid",
+  "executionId": "uuid",
+  "status": "string",
+  "runState": {
+    "runId": "string",
+    "elapsedTimeSeconds": 120.5,
+    "budgetConsumedCents": 250,
+    "taskStates": {},
+    "objectiveDriftScore": 0.05,
+    "anomalies": []
+  }
+}
+```
+
+---
+
+### `GET /ring-leader/runs/by-execution/:executionId/events`
+
+Get coordination event log for a Ring Leader run.
+
+**Response 200:**
+```json
+{
+  "runId": "uuid",
+  "events": [
+    { "type": "string", "timestamp": "ISO 8601", "payload": {} }
+  ]
+}
+```
+
+---
+
+### `GET /ring-leader/runs/by-execution/:executionId/synthesis`
+
+Get run synthesis and fitness scores for completed runs.
+
+**Response 200:**
+```json
+{
+  "runId": "uuid",
+  "executionId": "uuid",
+  "status": "string",
+  "synthesis": {},
+  "fitness": {
+    "coordinationScore": {
+      "collectiveOutcome": 0.9,
+      "driftPrevention": 0.85,
+      "reallocationEffectiveness": 0.8,
+      "budgetManagement": 0.95
+    },
+    "soulSelectionScore": {
+      "librarySearchQuality": 0.88,
+      "differentiationEffectiveness": 0.82,
+      "mutationDecisionQuality": 0.75,
+      "pioneerHandling": 0.9,
+      "selectionRetrospectiveQuality": 0.85
+    },
+    "compositeScore": 0.86
+  }
+}
+```
+
+---
+
+## Souls
+
+Prefix: `/souls`
+
+### `GET /souls`
+
+Paginated soul library with optional filtering.
+
+**Query:**
+- `category` (string, optional)
+- `agentClass` (string, optional)
+- `limit` (integer, 1-100, default: 50)
+- `offset` (integer, min: 0)
+
+**Response 200:**
+```json
+{
+  "souls": [
+    {
+      "id": "uuid",
+      "taskCategory": "string | null",
+      "generation": 2,
+      "isArchetype": false,
+      "archetypeName": "string | null",
+      "agentClass": "Novice | Understudy | Artisan | Retired | null",
+      "compositeScore": 0.85,
+      "createdAt": "ISO 8601"
+    }
+  ],
+  "total": 100,
+  "hasMore": true
+}
+```
+
+---
+
+### `GET /souls/categories`
+
+List distinct task categories in the soul library.
+
+**Response 200:**
+```json
+{ "categories": ["lead-generation", "content-writing"] }
+```
+
+---
+
+### `GET /souls/:id`
+
+Get full soul detail including content, dimensions, and linked bot data.
+
+**Response 200:** Full soul object with `soulContent`, `dimensions`, `constitutionDirectives`
+**Response 404:** Soul not found
+
+---
+
+## Category Benchmarks
+
+Prefix: `/category-benchmarks`
+
+### `GET /category-benchmarks`
+
+List all category benchmarks ordered by task category.
+
+**Response 200:**
+```json
+{
+  "benchmarks": [
+    {
+      "id": "uuid",
+      "taskCategory": "string",
+      "pioneerBotId": "uuid",
+      "pioneerSoulId": "uuid | null",
+      "pioneerExecutionId": "uuid",
+      "baselineCompositeScore": "string",
+      "confirmedRunCount": 3,
+      "thinDataFlag": false,
+      "benchmarkMature": true,
+      "standardPromotion": true,
+      "createdAt": "ISO 8601",
+      "updatedAt": "ISO 8601"
+    }
+  ]
+}
+```
+
+---
+
+## Decision Traces
+
+Prefix: `/decision-traces`
+
+### `GET /decision-traces/:botId`
+
+Paginated decision traces for a specific bot.
+
+**Query:**
+- `limit` (integer, 1-100, default: 50)
+- `offset` (integer, min: 0)
+
+**Response 200:**
+```json
+{
+  "traces": [
+    {
+      "id": "uuid",
+      "decisionType": "string",
+      "directiveReferenced": "string | null",
+      "attributionConfidence": "string | null",
+      "outcome": "string | null",
+      "decidedAt": "ISO 8601",
+      "executionId": "uuid"
+    }
+  ],
+  "total": 50,
+  "hasMore": false
+}
+```
+
+---
+
+## Negative Signals
+
+Prefix: `/negative-signals`
+
+### `GET /negative-signals`
+
+Paginated negative signal register with soul metadata.
+
+**Query:**
+- `failureType` (string, optional)
+- `limit` (integer, 1-100, default: 50)
+- `offset` (integer, min: 0)
+
+**Response 200:**
+```json
+{
+  "signals": [
+    {
+      "id": "uuid",
+      "soulId": "uuid",
+      "botId": "uuid",
+      "executionId": "uuid | null",
+      "failureType": "string",
+      "directiveFailureSummary": "string | null",
+      "registeredAt": "ISO 8601",
+      "taskCategory": "string | null",
+      "generation": 2
+    }
+  ],
+  "total": 25,
+  "hasMore": false
+}
+```
+
+---
+
+## Admin
+
+Prefix: `/admin`
+
+### `GET /admin/health`
+
+Deep health check probing GCE, Cloud SQL, Redis, and BullMQ. Returns 503 if any subsystem is unreachable.
+
+**Response 200:**
+```json
+{
+  "status": "healthy",
+  "subsystems": {
+    "gce": { "ok": true, "instanceCount": 1 },
+    "cloudSQL": { "ok": true, "latencyMs": 5 },
+    "redis": { "ok": true, "latencyMs": 2 },
+    "bullMQ": { "ok": true, "counts": { "waiting": 0, "active": 1, "failed": 0 } }
+  }
+}
+```
+
+---
+
+### `POST /admin/cleanup/decision-traces`
+
+Trigger TTL-based pruning of the decision_traces table (90-day / 5M-row policy).
+
+**Response 200:** `{ "status": "ok", "deleted": 1500 }`
+
+---
+
+### `POST /admin/waitlist`
+
+Accept an email for the early-access waitlist. Logs to Cloud Logging.
+
+**Request Body:** `{ "email": "string" }`
+
+**Response 200:** `{ "ok": true }`
+**Response 400:** Invalid email
+
+---
+
+### `POST /admin/retention/run`
+
+Trigger an immediate data retention sweep.
+
+**Response 200:** `{ "status": "ok", ... }`
+
+---
+
+### `GET /admin/retention/config`
+
+Get active retention configuration and next scheduled run time.
+
+**Response 200:**
+```json
+{
+  "config": { ... },
+  "nextScheduledRun": "ISO 8601 | null"
+}
+```
+
+---
+
+## Onboarding
+
+Prefix: `/onboarding`
+
+### `GET /onboarding/status`
+
+Check if the current user has completed onboarding (has a company in Paperclip).
+
+**Auth:** Session cookie required
+
+**Response 200:**
+```json
+{ "onboarded": true, "companyId": "uuid" }
+```
+
+**Response 401:** Not authenticated
+
+---
+
+### `POST /onboarding/summon`
+
+Create a company in Paperclip and spawn the initial agent team.
+
+**Auth:** Session cookie required
+
+**Request Body:**
+```json
+{
+  "businessType": "string",
+  "firstGoal": "string",
+  "budget": "<50 | 50-200 | 200+",
+  "companyName": "string",
+  "toolConnections": [{ "toolId": "string", "connectionId": "string" }]
+}
+```
+
+**Response 200:**
+```json
+{
+  "companyId": "uuid",
+  "companyName": "string",
+  "agents": [
+    { "id": "uuid", "name": "Mira", "role": "marketing", "tier": "sonnet", "archetype": "Creative Synthesizer" }
+  ],
+  "quickWins": [
+    { "agent": "Kael", "message": "Found 50 cold leads in HubSpot", "toolId": "hubspot" }
+  ]
+}
+```
+
+---
+
+## Cost Projections
+
+Prefix: `/companies`
+
+### `GET /companies/:id/costs/projections`
+
+Cost projection and forecasting based on burn rate.
+
+**Params:** `id` (uuid -- company ID)
+
+**Response 200:**
+```json
+{
+  "dailyBurnRateCents": 500,
+  "projectedMonthlyCostCents": 15000,
+  "daysUntilBudgetExhaustion": 20,
+  "trend": "increasing | decreasing | stable",
+  "breakdown": {
+    "llmInputTokensCents": 200,
+    "llmOutputTokensCents": 150,
+    "botHoursCents": 100,
+    "toolInvocationsCents": 50
+  },
+  "windowDays": 7,
+  "dataPoints": 5
+}
+```
+
+---
+
+## Paperclip Proxy
+
+The execution service proxies several path prefixes to the Paperclip API server. The browser never talks directly to Paperclip; all requests go through this proxy which forwards session cookies for auth.
+
+**Proxied prefixes:**
+- `/companies` and `/companies/*`
+- `/agents` and `/agents/*`
+- `/issues` and `/issues/*`
+- `/goals` and `/goals/*`
+- `/projects` and `/projects/*`
+- `/chat` and `/chat/*`
+- `/costs` and `/costs/*`
+- `/approvals` and `/approvals/*`
+- `/activity` and `/activity/*`
+- `/dashboard` and `/dashboard/*`
+- `/sidebar-badges` and `/sidebar-badges/*`
+- `/secrets` and `/secrets/*`
+
+**Methods:** GET, POST, PATCH, PUT, DELETE
+
+---
+
+## Auth
+
+### `GET /auth/*` and `POST /auth/*`
+
+BetterAuth routes for Google OAuth and session management. Bridges Web API Request/Response to Fastify.


### PR DESCRIPTION
## Summary
- Add comprehensive API reference for all execution-service HTTP endpoints (`docs/api-execution-service.md`) covering 18 route files and ~50 endpoints
- Add comprehensive API reference for all akasa-server HTTP endpoints (`docs/api-akasa-server.md`) covering 19 route files and ~70 endpoints
- Documents request/response schemas, authentication, query parameters, and example payloads for every endpoint

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Spot-check endpoint paths against actual route files
- [ ] Confirm request/response examples match TypeBox/interface schemas

Generated with [Claude Code](https://claude.com/claude-code)