### PR TITLE
feat(team): rebuild agent detail page with 5-tab layout

### DIFF
--- a/services/ui/src/routes/(app)/indra/+page.svelte
+++ b/services/ui/src/routes/(app)/indra/+page.svelte
@@ -27,6 +27,11 @@
     return 'Good evening';
   }
 
+  function agentInitial(agent: Record<string, unknown>): string {
+    const name = String(agent.name ?? '?');
+    return name.charAt(0).toUpperCase();
+  }
+
   function agentStatus(agent: Record<string, unknown>): string {
     const s = String(agent.status ?? 'idle');
     return s.charAt(0).toUpperCase() + s.slice(1);
@@ -37,16 +42,10 @@
   }
 
   function agentClassTier(agent: Record<string, unknown>): string {
+    const cls = agent.agentClass as string | undefined;
+    if (cls) return cls;
     const meta = agent.metadata as Record<string, unknown> | null;
     return String(meta?.agentClass ?? meta?.tier ?? 'novice');
-  }
-
-  function agentGoalName(agent: Record<string, unknown>): string | null {
-    const meta = agent.metadata as Record<string, unknown> | null;
-    const goalId = meta?.currentGoalId ?? meta?.goalId ?? null;
-    if (!goalId) return null;
-    const goal = goals.find((g) => g.id === goalId);
-    return goal ? String(goal.title ?? goal.name ?? '') : null;
   }
 
   function goalStatus(goal: Record<string, unknown>): string {
@@ -68,19 +67,9 @@
     const capCents = typeof meta.budgetCapCents === 'number' ? meta.budgetCapCents : null;
     if (spentCents == null && capCents == null) return null;
     return {
-      spent: spentCents != null ? `$${(spentCents / 100).toFixed(2)}` : '$0.00',
-      cap: capCents != null ? `$${(capCents / 100).toFixed(2)}` : '--',
+      spent: spentCents != null ? '$' + (spentCents / 100).toFixed(2) : '$0.00',
+      cap: capCents != null ? '$' + (capCents / 100).toFixed(2) : '--',
     };
-  }
-
-  function goalAssignedAgents(goal: Record<string, unknown>): string[] {
-    const meta = (goal.metadata ?? goal) as Record<string, unknown>;
-    const ids = meta.assignedAgentIds ?? meta.agentIds ?? [];
-    if (!Array.isArray(ids)) return [];
-    return ids.map((id) => {
-      const agent = agents.find((a) => a.id === id);
-      return agent ? String(agent.name) : String(id).slice(0, 8);
-    });
   }
 
   const MAX_ACTIVITY = 8;
@@ -108,10 +97,10 @@
 
     const actionLabel = action.charAt(0).toUpperCase() + action.slice(1);
     const entityLabel = entity.replace(/_/g, ' ');
-    const suffix = name ? `: ${name}` : '';
+    const suffix = name ? ': ' + name : '';
 
-    if (entity && action) return `${actionLabel} ${entityLabel}${suffix}`;
-    if (action) return `${actionLabel}${suffix}`;
+    if (entity && action) return actionLabel + ' ' + entityLabel + suffix;
+    if (action) return actionLabel + suffix;
     return String(event.type ?? 'Activity');
   }
 
@@ -121,23 +110,23 @@
     const diffMs = now.getTime() - d.getTime();
     const diffMin = Math.floor(diffMs / 60000);
     if (diffMin < 1) return 'just now';
-    if (diffMin < 60) return `${diffMin}m ago`;
+    if (diffMin < 60) return diffMin + 'm ago';
     const diffHrs = Math.floor(diffMin / 60);
-    if (diffHrs < 24) return `${diffHrs}h ago`;
+    if (diffHrs < 24) return diffHrs + 'h ago';
     return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
   }
 
   // ── Actions ─────────────────────────────────────────────────────
   async function handleApprove(id: string) {
     try {
-      await fetch(`/api/approvals/${id}/approve`, { method: 'POST' });
+      await fetch('/api/approvals/' + id + '/approve', { method: 'POST' });
       approvals = approvals.filter((a) => a.id !== id);
     } catch { /* non-critical */ }
   }
 
   async function handleDismiss(id: string) {
     try {
-      await fetch(`/api/approvals/${id}/dismiss`, { method: 'POST' });
+      await fetch('/api/approvals/' + id + '/dismiss', { method: 'POST' });
       approvals = approvals.filter((a) => a.id !== id);
     } catch { /* non-critical */ }
   }
@@ -149,16 +138,16 @@
     const budgetCents = typeof payload.budgetMonthlyCents === 'number' ? payload.budgetMonthlyCents : null;
     switch (type) {
       case 'hire_agent':
-        return agentName ? `Hire new agent: ${agentName}` : 'Hire a new agent';
+        return agentName ? 'Hire new agent: ' + agentName : 'Hire a new agent';
       case 'budget_override':
       case 'budget_override_required':
         return budgetCents != null
-          ? `Budget override — $${(budgetCents / 100).toFixed(0)}/mo requested`
+          ? 'Budget override — $' + (budgetCents / 100).toFixed(0) + '/mo requested'
           : 'Budget override requested';
       case 'tool_access':
-        return payload.toolName ? `Grant tool access: ${payload.toolName}` : 'Tool access request';
+        return payload.toolName ? 'Grant tool access: ' + payload.toolName : 'Tool access request';
       case 'execution_approval':
-        return payload.objectiveName ? `Run: ${payload.objectiveName}` : 'Execution approval';
+        return payload.objectiveName ? 'Run: ' + payload.objectiveName : 'Execution approval';
       default:
         return (payload.description as string) ?? type.replace(/_/g, ' ');
     }
@@ -178,7 +167,7 @@
         const cents = Math.round(parseFloat(goalBudget) * 100);
         if (!isNaN(cents) && cents > 0) body.budgetCapCents = cents;
       }
-      const res = await fetch(`/api/companies/${data.companyId}/goals`, {
+      const res = await fetch('/api/companies/' + data.companyId + '/goals', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
@@ -211,7 +200,7 @@
         activity = [{
           id: String(event.id),
           type: event.type,
-          description: `Agent ${payload.agentName ?? agentId?.slice(0, 8) ?? ''} status updated`,
+          description: 'Agent ' + (payload.agentName ?? agentId?.slice(0, 8) ?? '') + ' status updated',
           createdAt: event.createdAt,
           agentId: agentId ?? null,
         }, ...activity].slice(0, 50);
@@ -249,7 +238,7 @@
         activity = [{
           id: String(event.id),
           type: event.type,
-          description: runId ? `Run ${status} (${runId.slice(0, 8)})` : `Run ${status}`,
+          description: runId ? 'Run ' + status + ' (' + runId.slice(0, 8) + ')' : 'Run ' + status,
           createdAt: event.createdAt,
           agentId: (payload.agentId as string | undefined) ?? null,
         }, ...activity].slice(0, 50);
@@ -259,7 +248,7 @@
         activity = [{
           id: String(event.id),
           type: event.type,
-          description: `Agent promoted: ${payload.fromClass ?? '?'} -> ${payload.toClass ?? '?'}`,
+          description: 'Agent promoted: ' + (payload.fromClass ?? '?') + ' -> ' + (payload.toClass ?? '?'),
           createdAt: event.createdAt,
           agentId: (payload.botId as string | undefined) ?? null,
         }, ...activity].slice(0, 50);
@@ -269,22 +258,19 @@
   });
 </script>
 
-<div class="dashboard">
-  <!-- Greeting -->
+<div class="home">
+  <!-- Greeting + Quick Actions -->
   <header class="greeting">
-    <div class="greeting-text">
-      <h1 class="greeting-hello">{greeting()}, {data.userName}.</h1>
-      <p class="greeting-sub">
-        {#if agents.length > 0}
-          Your crew of {agents.length} is ready. Here's where things stand.
-        {:else}
-          Welcome to Akasa. Set your first goal to get started.
-        {/if}
-      </p>
-    </div>
+    <h1 class="greeting-hello">{greeting()}, {data.userName}.</h1>
+    <p class="greeting-sub">
+      {#if agents.length > 0}
+        Your crew of {agents.length} is ready. Here's where things stand.
+      {:else}
+        Welcome to Akasa. Set your first goal to get started.
+      {/if}
+    </p>
   </header>
 
-  <!-- Quick Actions Row -->
   <section class="quick-actions" aria-label="Quick actions">
     <button class="qa-btn qa-primary" onclick={() => { showGoalForm = true; }}>
       <span class="qa-icon">+</span>
@@ -294,13 +280,53 @@
       <span class="qa-icon">&#9654;</span>
       Chat with Indra
     </button>
-    <button class="qa-btn" onclick={() => goto('/office/agents')}>
+    <button class="qa-btn" onclick={() => goto('/office/agents/new')}>
       <span class="qa-icon">&#9670;</span>
       Add Agent
     </button>
   </section>
 
-  <!-- Active Goals -->
+  <!-- Section 1: Team Status -->
+  {#if agents.length > 0}
+    <section class="section" aria-label="Team status">
+      <h2 class="section-label">TEAM STATUS</h2>
+      <div class="team-row">
+        {#each agents as agent (agent.id)}
+          <div class="agent-card">
+            <div class="agent-avatar" class:avatar-working={agentStatusKey(agent) === 'working' || agentStatusKey(agent) === 'active'}>
+              <span class="avatar-letter">{agentInitial(agent)}</span>
+              <span class="status-indicator status-indicator-{agentStatusKey(agent)}"></span>
+            </div>
+            <span class="agent-name">{agent.name}</span>
+            <div class="agent-meta">
+              <span class="agent-status-text">{agentStatus(agent)}</span>
+              <span class="agent-class">{agentClassTier(agent)}</span>
+            </div>
+          </div>
+        {/each}
+      </div>
+    </section>
+  {/if}
+
+  <!-- Pending Approvals -->
+  {#if approvals.length > 0}
+    <section class="section" aria-label="Pending approvals">
+      <h2 class="section-label">PENDING APPROVALS</h2>
+      <div class="approvals-list">
+        {#each approvals as approval (approval.id)}
+          <div class="approval-card">
+            <span class="approval-desc">{approvalTitle(approval)}</span>
+            <div class="approval-actions">
+              <button class="btn-approve" onclick={() => handleApprove(String(approval.id))}>Approve</button>
+              <button class="btn-dismiss" onclick={() => handleDismiss(String(approval.id))}>Dismiss</button>
+            </div>
+          </div>
+        {/each}
+      </div>
+    </section>
+  {/if}
+
+  <!-- Section 2: Active Goals -->
   <section class="section" aria-label="Active goals">
     <div class="section-header">
       <h2 class="section-label">ACTIVE GOALS</h2>
@@ -380,62 +406,13 @@
                 <span class="goal-budget">{goalBudgetDisplay(goal)?.spent} / {goalBudgetDisplay(goal)?.cap}</span>
               {/if}
             </div>
-            {#if goalAssignedAgents(goal).length > 0}
-              <div class="goal-agents">
-                {#each goalAssignedAgents(goal) as name}
-                  <span class="goal-agent-tag">{name}</span>
-                {/each}
-              </div>
-            {/if}
           </div>
         {/each}
       </div>
     {/if}
   </section>
 
-  <!-- Team Status -->
-  {#if agents.length > 0}
-    <section class="section" aria-label="Team status">
-      <h2 class="section-label">TEAM STATUS</h2>
-      <div class="team-grid">
-        {#each agents as agent (agent.id)}
-          <div class="team-card">
-            <div class="team-header">
-              <span class="team-name">{agent.name}</span>
-              <span class="status-dot status-dot-{agentStatusKey(agent)}" title={agentStatus(agent)}></span>
-            </div>
-            <div class="team-badges">
-              <span class="badge badge-status badge-{agentStatusKey(agent)}">{agentStatus(agent)}</span>
-              <span class="badge badge-class">{agentClassTier(agent)}</span>
-            </div>
-            {#if agentGoalName(agent)}
-              <span class="team-goal">{agentGoalName(agent)}</span>
-            {/if}
-          </div>
-        {/each}
-      </div>
-    </section>
-  {/if}
-
-  <!-- Pending Approvals -->
-  {#if approvals.length > 0}
-    <section class="section" aria-label="Pending approvals">
-      <h2 class="section-label">PENDING APPROVALS</h2>
-      <div class="approvals-list">
-        {#each approvals as approval (approval.id)}
-          <div class="approval-card">
-            <span class="approval-desc">{approvalTitle(approval)}</span>
-            <div class="approval-actions">
-              <button class="btn-approve" onclick={() => handleApprove(String(approval.id))}>Approve</button>
-              <button class="btn-dismiss" onclick={() => handleDismiss(String(approval.id))}>Dismiss</button>
-            </div>
-          </div>
-        {/each}
-      </div>
-    </section>
-  {/if}
-
-  <!-- Activity Feed -->
+  <!-- Section 3: Activity Feed -->
   <section class="section" aria-label="Activity feed">
     <h2 class="section-label">ACTIVITY</h2>
     {#if activity.length === 0}
@@ -460,21 +437,20 @@
 </div>
 
 <style>
-  .dashboard {
+  .home {
     width: 100%;
-    max-width: 800px;
+    max-width: 840px;
     margin: 0 auto;
     padding: 0 24px 60px;
   }
 
-  /* ── Greeting ─────────────────────────────── */
   .greeting {
     padding: 40px 0 24px;
   }
 
   .greeting-hello {
     font-family: var(--font-display);
-    font-size: clamp(24px, 3.5vw, 34px);
+    font-size: clamp(24px, 3.5vw, 36px);
     font-weight: 600;
     color: var(--text);
     letter-spacing: -0.02em;
@@ -490,11 +466,10 @@
     line-height: 1.5;
   }
 
-  /* ── Quick Actions ────────────────────────── */
   .quick-actions {
     display: flex;
     gap: 10px;
-    padding-bottom: 28px;
+    padding-bottom: 32px;
     flex-wrap: wrap;
   }
 
@@ -521,7 +496,7 @@
 
   .qa-primary {
     background: var(--fo-plum);
-    color: white;
+    color: #fff;
     border-color: var(--fo-plum);
   }
 
@@ -535,7 +510,6 @@
     flex-shrink: 0;
   }
 
-  /* ── Sections ─────────────────────────────── */
   .section {
     padding: 20px 0;
   }
@@ -576,10 +550,143 @@
     opacity: 0.7;
   }
 
-  /* ── Goals Grid ───────────────────────────── */
+  .team-row {
+    display: flex;
+    gap: 16px;
+    overflow-x: auto;
+    padding-bottom: 4px;
+    scrollbar-width: thin;
+    scrollbar-color: var(--fo-bg3) transparent;
+  }
+
+  .team-row::-webkit-scrollbar {
+    height: 4px;
+  }
+
+  .team-row::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .team-row::-webkit-scrollbar-thumb {
+    background: var(--fo-bg3);
+    border-radius: 2px;
+  }
+
+  .agent-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    min-width: 88px;
+    padding: 14px 12px;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    transition: border-color 0.2s, transform 0.15s;
+    flex-shrink: 0;
+  }
+
+  .agent-card:hover {
+    border-color: var(--accent);
+    transform: translateY(-2px);
+  }
+
+  .agent-avatar {
+    position: relative;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: var(--fo-plum-p);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .agent-avatar.avatar-working {
+    background: var(--fo-plum);
+  }
+
+  .agent-avatar.avatar-working .avatar-letter {
+    color: #fff;
+  }
+
+  .avatar-letter {
+    font-family: var(--font-display);
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--fo-plum);
+    line-height: 1;
+  }
+
+  .status-indicator {
+    position: absolute;
+    bottom: 1px;
+    right: 1px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    border: 2px solid var(--card);
+  }
+
+  .status-indicator-working,
+  .status-indicator-active {
+    background: var(--success);
+  }
+
+  .status-indicator-idle {
+    background: var(--text-muted);
+  }
+
+  .status-indicator-paused {
+    background: var(--rose);
+  }
+
+  .status-indicator-complete,
+  .status-indicator-done {
+    background: var(--karma);
+  }
+
+  .agent-name {
+    font-family: var(--font-body);
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text);
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 80px;
+  }
+
+  .agent-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+  }
+
+  .agent-status-text {
+    font-family: var(--font-body);
+    font-size: 10px;
+    color: var(--text-muted);
+    text-transform: capitalize;
+  }
+
+  .agent-class {
+    font-family: var(--font-label);
+    font-size: 5px;
+    letter-spacing: 0.10em;
+    text-transform: uppercase;
+    color: var(--karma);
+    background: var(--fo-gold-p);
+    padding: 2px 6px;
+    border-radius: var(--radius-sm);
+  }
+
   .goals-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
     gap: 12px;
   }
 
@@ -676,24 +783,6 @@
     color: var(--text-muted);
   }
 
-  .goal-agents {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-  }
-
-  .goal-agent-tag {
-    font-family: var(--font-label);
-    font-size: 5px;
-    letter-spacing: 0.08em;
-    color: var(--accent-m);
-    background: var(--fo-plum-p);
-    padding: 2px 6px;
-    border-radius: var(--radius-sm);
-    text-transform: uppercase;
-  }
-
-  /* ── Goal Form ────────────────────────────── */
   .goal-form-card {
     background: var(--card);
     border: 1px solid var(--karma);
@@ -777,7 +866,7 @@
     font-family: var(--font-body);
     font-size: 13px;
     font-weight: 500;
-    color: white;
+    color: #fff;
     background: var(--fo-plum);
     border: none;
     border-radius: var(--radius-md);
@@ -803,94 +892,6 @@
 
   .btn-cancel:hover { border-color: var(--accent); }
 
-  /* ── Team Grid ────────────────────────────── */
-  .team-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-    gap: 10px;
-  }
-
-  .team-card {
-    background: var(--card);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-md);
-    padding: 14px 16px;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    transition: border-color 0.2s, transform 0.15s;
-  }
-
-  .team-card:hover {
-    border-color: var(--accent);
-    transform: translateY(-1px);
-  }
-
-  .team-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .team-name {
-    font-family: var(--font-display);
-    font-size: 17px;
-    font-weight: 600;
-    color: var(--text);
-    letter-spacing: -0.01em;
-  }
-
-  .status-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    flex-shrink: 0;
-  }
-
-  .status-dot-working, .status-dot-active { background: var(--success); }
-  .status-dot-idle { background: var(--text-muted); }
-  .status-dot-paused { background: var(--rose); }
-  .status-dot-complete, .status-dot-done { background: var(--karma); }
-
-  .team-badges {
-    display: flex;
-    gap: 6px;
-    flex-wrap: wrap;
-  }
-
-  .badge {
-    font-family: var(--font-label);
-    font-size: 5px;
-    letter-spacing: 0.10em;
-    text-transform: uppercase;
-    padding: 2px 6px;
-    border-radius: var(--radius-sm);
-  }
-
-  .badge-status {
-    color: var(--text-muted);
-    background: var(--fo-bg2);
-  }
-
-  .badge-working, .badge-active { color: var(--success); background: rgba(5, 150, 105, 0.08); }
-  .badge-idle { color: var(--text-muted); background: var(--fo-bg2); }
-  .badge-paused { color: var(--rose); background: rgba(219, 39, 119, 0.08); }
-
-  .badge-class {
-    color: var(--karma);
-    background: var(--fo-gold-p);
-  }
-
-  .team-goal {
-    font-family: var(--font-body);
-    font-size: 11px;
-    color: var(--accent-m);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  /* ── Approvals ────────────────────────────── */
   .approvals-list {
     display: flex;
     flex-direction: column;
@@ -926,7 +927,7 @@
     font-family: var(--font-body);
     font-size: 12px;
     font-weight: 500;
-    color: white;
+    color: #fff;
     background: var(--accent);
     border: none;
     border-radius: var(--radius-md);
@@ -951,7 +952,6 @@
 
   .btn-dismiss:hover { border-color: var(--accent); }
 
-  /* ── Activity Feed ────────────────────────── */
   .activity-list {
     list-style: none;
     margin: 0;
@@ -1022,9 +1022,8 @@
     font-style: italic;
   }
 
-  /* ── Responsive ───────────────────────────── */
   @media (max-width: 768px) {
-    .dashboard {
+    .home {
       padding: 0 16px 40px;
     }
 
@@ -1050,17 +1049,22 @@
       grid-template-columns: 1fr;
     }
 
-    .team-grid {
-      grid-template-columns: repeat(2, 1fr);
-      gap: 8px;
+    .team-row {
+      gap: 10px;
     }
 
-    .team-card {
-      padding: 12px;
+    .agent-card {
+      min-width: 76px;
+      padding: 10px 8px;
     }
 
-    .team-name {
-      font-size: 15px;
+    .agent-avatar {
+      width: 38px;
+      height: 38px;
+    }
+
+    .avatar-letter {
+      font-size: 17px;
     }
 
     .approval-card {
@@ -1084,7 +1088,7 @@
   }
 
   @media (max-width: 480px) {
-    .dashboard {
+    .home {
       padding: 0 12px 32px;
     }
 
@@ -1100,17 +1104,18 @@
       flex-direction: column;
     }
 
-    .team-grid {
-      grid-template-columns: 1fr 1fr;
-      gap: 6px;
+    .agent-card {
+      min-width: 68px;
+      padding: 8px 6px;
     }
 
-    .team-card {
-      padding: 10px;
+    .agent-avatar {
+      width: 34px;
+      height: 34px;
     }
 
-    .team-name {
-      font-size: 14px;
+    .avatar-letter {
+      font-size: 15px;
     }
 
     .section-label {

--- a/services/ui/src/routes/(app)/team/[id]/+page.svelte
+++ b/services/ui/src/routes/(app)/team/[id]/+page.svelte
@@ -14,7 +14,9 @@
 
   let { data }: { data: PageData } = $props();
 
-  let activeTab = $state<'edit' | 'skills' | 'activity' | 'performance' | 'danger'>('edit');
+  type TabId = 'profile' | 'skills' | 'tools' | 'history' | 'evolution';
+  let activeTab = $state<TabId>('profile');
+
   let editName = $state(data.agent.name);
   let editDescription = $state(data.agent.description ?? '');
   let editAdapter = $state(data.agent.adapter ?? 'claude');
@@ -22,6 +24,7 @@
   let editError = $state('');
   let editSuccess = $state(false);
 
+  let showDeleteConfirm = $state(false);
   let deleteConfirmName = $state('');
   let deleteLoading = $state(false);
   let deleteError = $state('');
@@ -41,31 +44,25 @@
     { value: 'openclaw', label: 'OpenClaw' },
   ];
 
-  const CLASS_CAPACITY: Record<string, number> = {
-    Novice: 3,
-    Understudy: 5,
-    Artisan: 8,
-    Retired: 0,
-  };
-  const CAPACITY = $derived(CLASS_CAPACITY[data.agent?.agentClass ?? 'Novice'] ?? 3);
+  const CLASS_CAPACITY: Record<string, number> = { Novice: 3, Understudy: 5, Artisan: 8, Retired: 0 };
+  const agentClass = $derived(data.agent?.agentClass ?? 'Novice');
+  const CAPACITY = $derived(CLASS_CAPACITY[agentClass] ?? 3);
+
+  const CLASS_COLORS: Record<string, string> = { Novice: '#3B82F6', Understudy: '#8B5CF6', Artisan: '#F59E0B', Retired: 'var(--text-muted)' };
+  const CLASS_PROGRESSION = ['Novice', 'Understudy', 'Artisan'];
 
   const CATEGORY_COLORS: Record<string, string> = {
-    communication: 'var(--accent-teal)',
-    analysis: 'var(--accent)',
-    creation: 'var(--karma)',
-    automation: 'var(--accent-rose)',
-    research: 'var(--accent-m)',
-    coordination: 'var(--accent-teal)',
-    monitoring: 'var(--karma)',
-    other: 'var(--muted)',
+    communication: 'var(--accent-teal)', analysis: 'var(--accent)', creation: 'var(--karma)',
+    automation: 'var(--accent-rose)', research: 'var(--accent-m)', coordination: 'var(--accent-teal)',
+    monitoring: 'var(--karma)', other: 'var(--muted)',
   };
 
-  const TABS = [
-    { id: 'edit' as const, label: 'EDIT' },
-    { id: 'skills' as const, label: 'SKILLS' },
-    { id: 'activity' as const, label: 'ACTIVITY' },
-    { id: 'performance' as const, label: 'PERFORMANCE' },
-    { id: 'danger' as const, label: 'DANGER ZONE' },
+  const TABS: { id: TabId; label: string }[] = [
+    { id: 'profile', label: 'PROFILE' },
+    { id: 'skills', label: 'SKILLS' },
+    { id: 'tools', label: 'TOOLS' },
+    { id: 'history', label: 'HISTORY' },
+    { id: 'evolution', label: 'EVOLUTION' },
   ];
 
   const slotsUsed = $derived(skillsEquipped.length);
@@ -74,9 +71,7 @@
 
   const availableSkills = $derived.by(() => {
     let filtered = skillsAll.filter((s) => !equippedIds.has(s.id));
-    if (skillFilterCategory) {
-      filtered = filtered.filter((s) => s.category === skillFilterCategory);
-    }
+    if (skillFilterCategory) filtered = filtered.filter((s) => s.category === skillFilterCategory);
     return filtered;
   });
 
@@ -89,19 +84,17 @@
     (data.spendByAgent as Array<{ agentId: string; agentName?: string | null; totalCents?: number; date?: string; cents?: number }>)
       .filter((p) => p.agentId === data.agent.id)
   );
+  const totalAgentSpend = $derived(agentCostData.reduce((sum, p) => sum + (p.cents ?? p.totalCents ?? 0), 0));
 
-  const totalAgentSpend = $derived(
-    agentCostData.reduce((sum, p) => sum + (p.cents ?? p.totalCents ?? 0), 0)
+  const toolConnections = $derived(
+    (data.toolConnections ?? []) as Array<{ id: string; toolName: string; provider: string; status: string; createdAt: string }>
   );
 
   async function loadSkills() {
     skillsLoading = true;
     skillsError = null;
     try {
-      const [equippedRes, allSkillsRes] = await Promise.allSettled([
-        getAgentSkills(data.agent.id),
-        getSkills(data.userId),
-      ]);
+      const [equippedRes, allSkillsRes] = await Promise.allSettled([getAgentSkills(data.agent.id), getSkills(data.userId)]);
       skillsEquipped = equippedRes.status === 'fulfilled' ? equippedRes.value : [];
       skillsAll = allSkillsRes.status === 'fulfilled' ? allSkillsRes.value : [];
     } catch (err) {
@@ -114,229 +107,142 @@
   async function handleSkillEquip(skillId: string) {
     if (slotsFree <= 0) return;
     skillActionLoading = skillId;
-    try {
-      await equipSkill(data.agent.id, skillId, data.userId);
-      await loadSkills();
-    } catch (err) {
-      skillsError = (err as Error).message;
-    } finally {
-      skillActionLoading = null;
-    }
+    try { await equipSkill(data.agent.id, skillId, data.userId); await loadSkills(); }
+    catch (err) { skillsError = (err as Error).message; }
+    finally { skillActionLoading = null; }
   }
 
   async function handleSkillUnequip(skillId: string) {
     skillActionLoading = skillId;
-    try {
-      await unequipSkill(data.agent.id, skillId);
-      await loadSkills();
-    } catch (err) {
-      skillsError = (err as Error).message;
-    } finally {
-      skillActionLoading = null;
-    }
+    try { await unequipSkill(data.agent.id, skillId); await loadSkills(); }
+    catch (err) { skillsError = (err as Error).message; }
+    finally { skillActionLoading = null; }
   }
 
-  function formatCents(cents: number): string {
-    return `$${(cents / 100).toFixed(2)}`;
-  }
-
-  function formatDate(dateStr: string): string {
-    return new Date(dateStr).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  }
-
-  function formatDateTime(dateStr: string): string {
-    return new Date(dateStr).toLocaleString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-  }
+  function formatCents(cents: number): string { return `$${(cents / 100).toFixed(2)}`; }
+  function formatDate(dateStr: string): string { return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }); }
+  function formatDateTime(dateStr: string): string { return new Date(dateStr).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }); }
 
   function getStatusLabel(status: string | null | undefined): string {
-    switch (status) {
-      case 'working':
-        return 'working';
-      case 'complete':
-      case 'done':
-        return 'done';
-      default:
-        return 'idle';
-    }
+    switch (status) { case 'working': return 'Working'; case 'complete': case 'done': return 'Done'; default: return 'Idle'; }
   }
-
-  function getStatusColor(status: string | null | undefined): string {
-    switch (status) {
-      case 'working':
-        return 'var(--fo-gold)';
-      case 'complete':
-      case 'done':
-        return 'var(--accent-teal)';
-      default:
-        return 'var(--text-muted)';
-    }
-  }
-
-  function getTierLabel(adapter: string | null | undefined): string {
-    if (!adapter) return '';
-    if (adapter.includes('haiku') || adapter.includes('junior')) return 'JUNIOR';
-    if (adapter.includes('sonnet') || adapter.includes('mid')) return 'MID';
-    if (adapter.includes('opus') || adapter.includes('senior')) return 'SENIOR';
-    return adapter.toUpperCase();
-  }
-
-  function getTierColor(adapter: string | null | undefined): string {
-    if (!adapter) return 'var(--text-muted)';
-    if (adapter.includes('haiku') || adapter.includes('junior')) return 'var(--tier-junior)';
-    if (adapter.includes('sonnet') || adapter.includes('mid')) return 'var(--tier-mid)';
-    if (adapter.includes('opus') || adapter.includes('senior')) return 'var(--tier-senior)';
-    return 'var(--text-muted)';
-  }
+  function getStatusColor(status: string | null | undefined): string { return status === 'working' ? '#22c55e' : '#9ca3af'; }
+  function getClassColor(cls: string | null | undefined): string { return CLASS_COLORS[cls ?? 'Novice'] ?? '#3B82F6'; }
 
   async function handleSaveEdit() {
-    editSaving = true;
-    editError = '';
-    editSuccess = false;
+    editSaving = true; editError = ''; editSuccess = false;
     try {
-      await updateAgent(data.agent.id, {
-        name: editName.trim(),
-        description: editDescription.trim() || undefined,
-        adapter: editAdapter,
-      });
+      await updateAgent(data.agent.id, { name: editName.trim(), description: editDescription.trim() || undefined, adapter: editAdapter });
       editSuccess = true;
       data.agent.name = editName.trim();
       data.agent.description = editDescription.trim() || null;
       data.agent.adapter = editAdapter;
-    } catch (err) {
-      editError = (err as Error).message ?? 'Failed to save changes';
-    } finally {
-      editSaving = false;
-    }
+    } catch (err) { editError = (err as Error).message ?? 'Failed to save changes'; }
+    finally { editSaving = false; }
   }
 
   async function handleDelete() {
-    if (deleteConfirmName !== data.agent.name) {
-      deleteError = 'Agent name does not match';
-      return;
-    }
-    deleteLoading = true;
-    deleteError = '';
-    try {
-      await deleteAgent(data.agent.id);
-      goto('/team');
-    } catch (err) {
-      deleteError = (err as Error).message ?? 'Failed to delete agent';
-      deleteLoading = false;
-    }
+    if (deleteConfirmName !== data.agent.name) { deleteError = 'Agent name does not match'; return; }
+    deleteLoading = true; deleteError = '';
+    try { await deleteAgent(data.agent.id); goto('/team'); }
+    catch (err) { deleteError = (err as Error).message ?? 'Failed to delete agent'; deleteLoading = false; }
   }
 
   function resetEditForm() {
-    editName = data.agent.name;
-    editDescription = data.agent.description ?? '';
-    editAdapter = data.agent.adapter ?? 'claude';
-    editError = '';
-    editSuccess = false;
+    editName = data.agent.name; editDescription = data.agent.description ?? '';
+    editAdapter = data.agent.adapter ?? 'claude'; editError = ''; editSuccess = false;
   }
 
-  $effect(() => {
-    if (activeTab === 'skills') {
-      loadSkills();
-    }
-  });
+  $effect(() => { if (activeTab === 'skills') loadSkills(); });
 </script>
 
 <div class="agent-detail">
-  <div class="back-row">
-    <a href="/team" class="back-link">&larr; Agents</a>
-  </div>
+  <div class="back-row"><a href="/team" class="back-link">&larr; Team</a></div>
 
   <div class="agent-header">
-    <h1 class="agent-name">{data.agent.name}</h1>
+    <div class="header-identity">
+      <div class="avatar" style="background: {getClassColor(agentClass)}15; border-color: {getClassColor(agentClass)}40">
+        <span class="avatar-letter" style="color: {getClassColor(agentClass)}">{data.agent.name.charAt(0).toUpperCase()}</span>
+      </div>
+      <div class="header-text">
+        <h1 class="agent-name">{data.agent.name}</h1>
+        {#if data.agent.description}<p class="agent-desc">{data.agent.description}</p>{/if}
+      </div>
+    </div>
     <div class="agent-badges">
-      <span class="status-badge" style="color: {getStatusColor(data.agent.status)}">
+      <span class="status-badge">
         <span class="status-dot" style="background: {getStatusColor(data.agent.status)}"></span>
         {getStatusLabel(data.agent.status)}
       </span>
-      {#if data.agent.adapter}
-        <span class="tier-badge" style="color: {getTierColor(data.agent.adapter)}">
-          {getTierLabel(data.agent.adapter)}
-        </span>
+      <span class="class-badge" style="color: {getClassColor(agentClass)}; border-color: {getClassColor(agentClass)}40; background: {getClassColor(agentClass)}10">
+        {agentClass.toUpperCase()}
+      </span>
+      {#if data.agent.compositeScore}
+        <span class="score-badge">{parseFloat(data.agent.compositeScore).toFixed(1)}</span>
       {/if}
     </div>
   </div>
 
   <nav class="tab-nav" aria-label="Agent detail tabs">
     {#each TABS as tab}
-      <button
-        class="tab-btn"
-        class:active={activeTab === tab.id}
-        onclick={() => (activeTab = tab.id)}
-        aria-selected={activeTab === tab.id}
-      >{tab.label}</button>
+      <button class="tab-btn" class:active={activeTab === tab.id} onclick={() => (activeTab = tab.id)} aria-selected={activeTab === tab.id}>{tab.label}</button>
     {/each}
   </nav>
 
   <div class="tab-content">
-    {#if activeTab === 'edit'}
+    {#if activeTab === 'profile'}
       <form class="edit-form" onsubmit={(e) => { e.preventDefault(); handleSaveEdit(); }}>
         <div class="field">
           <label for="name" class="field-label">Name</label>
           <input id="name" type="text" bind:value={editName} class="field-input" required />
         </div>
-
         <div class="field">
           <label for="description" class="field-label">Description</label>
-          <textarea
-            id="description"
-            bind:value={editDescription}
-            class="field-input field-textarea"
-            rows="3"
-          ></textarea>
+          <textarea id="description" bind:value={editDescription} class="field-input field-textarea" rows="3"></textarea>
         </div>
-
         <div class="field">
           <label for="adapter" class="field-label">Model / Adapter</label>
           <select id="adapter" bind:value={editAdapter} class="field-input field-select">
-            {#each ADAPTERS as opt}
-              <option value={opt.value}>{opt.label}</option>
-            {/each}
+            {#each ADAPTERS as opt}<option value={opt.value}>{opt.label}</option>{/each}
           </select>
         </div>
-
-        {#if editError}
-          <p class="field-error" role="alert">{editError}</p>
-        {/if}
-
-        {#if editSuccess}
-          <p class="field-success" role="status">Changes saved successfully</p>
-        {/if}
-
+        {#if editError}<p class="field-error" role="alert">{editError}</p>{/if}
+        {#if editSuccess}<p class="field-success" role="status">Changes saved successfully</p>{/if}
         <div class="form-actions">
           <button type="button" class="btn-secondary" onclick={resetEditForm}>Reset</button>
-          <button type="submit" class="btn-primary" disabled={editSaving}>
-            {editSaving ? 'Saving...' : 'Save changes'}
-          </button>
+          <button type="submit" class="btn-primary" disabled={editSaving}>{editSaving ? 'Saving...' : 'Save changes'}</button>
         </div>
       </form>
 
       <div class="agent-meta">
-        <div class="meta-row">
-          <span class="meta-label">Adapter</span>
-          <span class="meta-value">{data.agent.adapter ?? '—'}</span>
-        </div>
-        <div class="meta-row">
-          <span class="meta-label">Created</span>
-          <span class="meta-value">{formatDate(data.agent.createdAt)}</span>
-        </div>
-        <div class="meta-row">
-          <span class="meta-label">Last updated</span>
-          <span class="meta-value">{formatDate(data.agent.updatedAt)}</span>
-        </div>
+        <div class="meta-row"><span class="meta-label">Class</span><span class="meta-value" style="color: {getClassColor(agentClass)}">{agentClass}</span></div>
+        <div class="meta-row"><span class="meta-label">Adapter</span><span class="meta-value">{data.agent.adapter ?? '---'}</span></div>
+        <div class="meta-row"><span class="meta-label">Created</span><span class="meta-value">{formatDate(data.agent.createdAt)}</span></div>
+        <div class="meta-row"><span class="meta-label">Last updated</span><span class="meta-value">{formatDate(data.agent.updatedAt)}</span></div>
       </div>
+
+      <div class="delete-section">
+        {#if !showDeleteConfirm}
+          <button class="btn-danger-outline" onclick={() => (showDeleteConfirm = true)}>Delete agent</button>
+        {:else}
+          <div class="danger-box">
+            <h3 class="danger-title">Delete agent</h3>
+            <p class="danger-desc">This will permanently delete <strong>{data.agent.name}</strong> and remove it from all assignments. This action cannot be undone.</p>
+            <div class="danger-confirm">
+              <label for="delete-confirm" class="field-label">Type <strong>{data.agent.name}</strong> to confirm</label>
+              <input id="delete-confirm" type="text" bind:value={deleteConfirmName} class="field-input" placeholder={data.agent.name} />
+            </div>
+            {#if deleteError}<p class="field-error" role="alert">{deleteError}</p>{/if}
+            <div class="form-actions">
+              <button class="btn-secondary" onclick={() => { showDeleteConfirm = false; deleteConfirmName = ''; deleteError = ''; }}>Cancel</button>
+              <button class="btn-danger" onclick={handleDelete} disabled={deleteConfirmName !== data.agent.name || deleteLoading}>
+                {deleteLoading ? 'Deleting...' : 'Delete agent'}
+              </button>
+            </div>
+          </div>
+        {/if}
+      </div>
+
     {:else if activeTab === 'skills'}
       <div class="skill-loadout">
         <div class="loadout-header">
@@ -344,24 +250,17 @@
           <div class="slot-meter">
             <span class="slot-label">SLOTS</span>
             <div class="slot-bar">
-              {#each Array(CAPACITY) as _, i}
-                <div class="slot-pip" class:filled={i < slotsUsed}></div>
-              {/each}
+              {#each Array(CAPACITY) as _, i}<div class="slot-pip" class:filled={i < slotsUsed}></div>{/each}
             </div>
             <span class="slot-count">{slotsUsed}/{CAPACITY}</span>
           </div>
         </div>
+        <p class="capacity-note">{agentClass} agents can equip up to {CAPACITY} skills.</p>
 
         {#if skillsLoading}
-          <div class="loading-state">
-            <span class="loading-dot"></span>
-            <span class="loading-text">Loading skills...</span>
-          </div>
+          <div class="loading-state"><span class="loading-dot"></span><span class="loading-text">Loading skills...</span></div>
         {:else if skillsError}
-          <div class="error-state">
-            <p class="error-text">{skillsError}</p>
-            <button class="retry-btn" onclick={loadSkills}>Retry</button>
-          </div>
+          <div class="error-state"><p class="error-text">{skillsError}</p><button class="retry-btn" onclick={loadSkills}>Retry</button></div>
         {:else}
           <div class="equipped-section">
             {#if skillsEquipped.length === 0}
@@ -371,21 +270,11 @@
                 {#each skillsEquipped as skill}
                   <div class="equipped-card">
                     <div class="skill-info">
-                      <span
-                        class="skill-cat-dot"
-                        style="background: {CATEGORY_COLORS[skill.skillCategory] ?? 'var(--muted)'}"
-                      ></span>
-                      <div class="skill-meta">
-                        <span class="skill-name">{skill.skillName}</span>
-                        <span class="skill-desc">{skill.skillDescription}</span>
-                      </div>
+                      <span class="skill-cat-dot" style="background: {CATEGORY_COLORS[skill.skillCategory] ?? 'var(--muted)'}"></span>
+                      <div class="skill-meta"><span class="skill-name">{skill.skillName}</span><span class="skill-desc">{skill.skillDescription}</span></div>
                       <span class="skill-version">v{skill.skillVersion}</span>
                     </div>
-                    <button
-                      class="unequip-btn"
-                      disabled={skillActionLoading === skill.skillId}
-                      onclick={() => handleSkillUnequip(skill.skillId)}
-                    >
+                    <button class="unequip-btn" disabled={skillActionLoading === skill.skillId} onclick={() => handleSkillUnequip(skill.skillId)}>
                       {skillActionLoading === skill.skillId ? '...' : 'UNEQUIP'}
                     </button>
                   </div>
@@ -403,54 +292,25 @@
             <div class="library-section">
               {#if skillCategories.length > 1}
                 <div class="filter-bar">
-                  <button
-                    class="filter-chip"
-                    class:active={skillFilterCategory === ''}
-                    onclick={() => (skillFilterCategory = '')}
-                  >ALL</button>
+                  <button class="filter-chip" class:active={skillFilterCategory === ''} onclick={() => (skillFilterCategory = '')}>ALL</button>
                   {#each skillCategories as cat}
-                    <button
-                      class="filter-chip"
-                      class:active={skillFilterCategory === cat}
-                      onclick={() => (skillFilterCategory = cat)}
-                    >{cat.toUpperCase()}</button>
+                    <button class="filter-chip" class:active={skillFilterCategory === cat} onclick={() => (skillFilterCategory = cat)}>{cat.toUpperCase()}</button>
                   {/each}
                 </div>
               {/if}
-
               {#if availableSkills.length === 0}
-                <p class="empty-msg">
-                  {skillsAll.length === 0
-                    ? 'No skills in your library. Create skills from the Skills page.'
-                    : 'All matching skills are already equipped.'}
-                </p>
+                <p class="empty-msg">{skillsAll.length === 0 ? 'No skills in your library. Create skills from the Skills page.' : 'All matching skills are already equipped.'}</p>
               {:else}
                 <div class="available-list">
                   {#each availableSkills as skill}
                     <div class="available-card">
                       <div class="skill-info">
-                        <span
-                          class="skill-cat-dot"
-                          style="background: {CATEGORY_COLORS[skill.category] ?? 'var(--muted)'}"
-                        ></span>
-                        <div class="skill-meta">
-                          <span class="skill-name">{skill.name}</span>
-                          <span class="skill-desc">{skill.description}</span>
-                        </div>
+                        <span class="skill-cat-dot" style="background: {CATEGORY_COLORS[skill.category] ?? 'var(--muted)'}"></span>
+                        <div class="skill-meta"><span class="skill-name">{skill.name}</span><span class="skill-desc">{skill.description}</span></div>
                         <span class="skill-class-badge">{skill.minAgentClass}</span>
                       </div>
-                      <button
-                        class="equip-btn"
-                        disabled={slotsFree <= 0 || skillActionLoading === skill.id}
-                        onclick={() => handleSkillEquip(skill.id)}
-                      >
-                        {#if skillActionLoading === skill.id}
-                          ...
-                        {:else if slotsFree <= 0}
-                          FULL
-                        {:else}
-                          EQUIP
-                        {/if}
+                      <button class="equip-btn" disabled={slotsFree <= 0 || skillActionLoading === skill.id} onclick={() => handleSkillEquip(skill.id)}>
+                        {#if skillActionLoading === skill.id}...{:else if slotsFree <= 0}FULL{:else}EQUIP{/if}
                       </button>
                     </div>
                   {/each}
@@ -460,27 +320,46 @@
           {/if}
         {/if}
       </div>
-    {:else if activeTab === 'activity'}
-      <div class="activity-section">
+
+    {:else if activeTab === 'tools'}
+      <div class="tools-section">
+        <h3 class="section-title">Tool Connections</h3>
+        {#if toolConnections.length === 0}
+          <div class="empty-tools">
+            <p class="empty-msg">No tool connections available.</p>
+            <a href="/tools/import" class="btn-secondary">Import tools</a>
+          </div>
+        {:else}
+          <div class="tool-list">
+            {#each toolConnections as tool}
+              <div class="tool-card">
+                <div class="tool-info">
+                  <span class="tool-icon">
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M6.5 1.5L8 3l1.5-1.5M3 6.5L1.5 8 3 9.5M13 6.5L14.5 8 13 9.5M6.5 14.5L8 13l1.5 1.5M4.5 4.5l7 7M11.5 4.5l-7 7" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/></svg>
+                  </span>
+                  <div class="tool-meta"><span class="tool-name">{tool.toolName}</span><span class="tool-provider">{tool.provider}</span></div>
+                </div>
+                <span class="tool-status" class:connected={tool.status === 'connected'}>{tool.status === 'connected' ? 'Connected' : tool.status}</span>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </div>
+
+    {:else if activeTab === 'history'}
+      <div class="history-section">
+        <div class="perf-grid">
+          <div class="perf-card"><h3 class="perf-card-title">TOTAL SPEND</h3><p class="perf-card-value">{formatCents(totalAgentSpend)}</p></div>
+          <div class="perf-card"><h3 class="perf-card-title">EXECUTIONS</h3><p class="perf-card-value">{data.activity.length}</p></div>
+        </div>
         {#if data.activity.length === 0}
-          <p class="empty-state">No activity recorded for this agent yet.</p>
+          <p class="empty-state-text">No execution history for this agent yet.</p>
         {:else}
           <div class="activity-list">
             {#each data.activity as event}
               <div class="activity-row">
-                <div
-                  class="activity-icon"
-                  class:execution={event.type === 'execution'}
-                  class:skill={event.type === 'skill'}
-                  class:karma={event.type === 'karma'}
-                >
-                  {#if event.type === 'execution'}
-                    <span class="icon-run">▶</span>
-                  {:else if event.type === 'skill'}
-                    <span class="icon-skill">⚡</span>
-                  {:else}
-                    <span class="icon-karma">◆</span>
-                  {/if}
+                <div class="activity-icon" class:execution={event.type === 'execution'} class:skill={event.type === 'skill'} class:karma={event.type === 'karma'}>
+                  {#if event.type === 'execution'}<span>&#9654;</span>{:else if event.type === 'skill'}<span>&#9889;</span>{:else}<span>&#9670;</span>{/if}
                 </div>
                 <div class="activity-info">
                   <span class="activity-desc">{event.description ?? event.type}</span>
@@ -490,28 +369,11 @@
             {/each}
           </div>
         {/if}
-      </div>
-    {:else if activeTab === 'performance'}
-      <div class="performance-section">
-        <div class="perf-grid">
-          <div class="perf-card">
-            <h3 class="perf-card-title">TOTAL SPEND</h3>
-            <p class="perf-card-value">{formatCents(totalAgentSpend)}</p>
-          </div>
-          <div class="perf-card">
-            <h3 class="perf-card-title">COST ENTRIES</h3>
-            <p class="perf-card-value">{agentCostData.length}</p>
-          </div>
-        </div>
-
         {#if agentCostData.length > 0}
           <div class="cost-history">
             <h3 class="perf-section-title">COST HISTORY</h3>
             <div class="cost-table">
-              <div class="cost-header">
-                <span>Date</span>
-                <span>Amount</span>
-              </div>
+              <div class="cost-header"><span>Date</span><span>Amount</span></div>
               {#each agentCostData as entry}
                 <div class="cost-row">
                   <span class="cost-date">{formatDate(entry.date ?? '')}</span>
@@ -520,821 +382,205 @@
               {/each}
             </div>
           </div>
-        {:else}
-          <p class="empty-state">No cost data available for this agent.</p>
         {/if}
       </div>
-    {:else if activeTab === 'danger'}
-      <div class="danger-section">
-        <h2 class="danger-title">Delete agent</h2>
-        <p class="danger-desc">
-          This will permanently delete <strong>{data.agent.name}</strong> and remove it from all
-          assignments. This action cannot be undone.
-        </p>
-        <div class="danger-confirm">
-          <label for="delete-confirm" class="field-label">
-            Type <strong>{data.agent.name}</strong> to confirm deletion
-          </label>
-          <input
-            id="delete-confirm"
-            type="text"
-            bind:value={deleteConfirmName}
-            class="field-input"
-            placeholder={data.agent.name}
-          />
+
+    {:else if activeTab === 'evolution'}
+      <div class="evolution-section">
+        <div class="class-progression">
+          <h3 class="section-title">Class Progression</h3>
+          <div class="progression-track">
+            {#each CLASS_PROGRESSION as cls, i}
+              {@const isCurrent = cls === agentClass}
+              {@const isPast = CLASS_PROGRESSION.indexOf(agentClass) > i}
+              <div class="progression-step" class:current={isCurrent} class:past={isPast}>
+                <div class="step-dot" style="background: {isCurrent || isPast ? getClassColor(cls) : 'var(--border, var(--fo-border))'}; border-color: {getClassColor(cls)}40"></div>
+                <span class="step-label" style="color: {isCurrent ? getClassColor(cls) : 'var(--text-muted)'}">{cls}</span>
+                <span class="step-capacity">{CLASS_CAPACITY[cls]} skills</span>
+              </div>
+              {#if i < CLASS_PROGRESSION.length - 1}
+                <div class="step-connector" class:filled={isPast}></div>
+              {/if}
+            {/each}
+          </div>
         </div>
-        {#if deleteError}
-          <p class="field-error" role="alert">{deleteError}</p>
+
+        {#if data.agent.compositeScore}
+          <div class="score-section">
+            <h3 class="section-title">Composite Fitness Score</h3>
+            <div class="score-display">
+              <span class="score-value">{parseFloat(data.agent.compositeScore).toFixed(2)}</span>
+              <span class="score-max">/ 10.0</span>
+            </div>
+          </div>
         {/if}
-        <button
-          class="btn-danger"
-          onclick={handleDelete}
-          disabled={deleteConfirmName !== data.agent.name || deleteLoading}
-        >
-          {deleteLoading ? 'Deleting...' : 'Delete agent'}
-        </button>
+
+        <div class="lineage-section">
+          <h3 class="section-title">Soul Lineage</h3>
+          <p class="empty-msg">Soul lineage data is populated after evolution runs.</p>
+        </div>
       </div>
     {/if}
   </div>
 </div>
 
 <style>
-  .agent-detail {
-    max-width: 800px;
-  }
-
-  .back-row {
-    margin-bottom: var(--space-xl);
-  }
-
-  .back-link {
-    font-family: var(--font-body);
-    font-size: 13px;
-    color: var(--text-muted);
-    text-decoration: none;
-    transition: color 0.15s;
-  }
-
-  .back-link:hover {
-    color: var(--fo-plum);
-  }
-
-  .agent-header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: var(--space-lg);
-    margin-bottom: var(--space-xl);
-    flex-wrap: wrap;
-  }
-
-  .agent-name {
-    font-family: var(--font-display);
-    font-size: 18px;
-    font-weight: 600;
-    color: var(--fo-plum);
-    line-height: 1.2;
-    margin: 0;
-  }
-
-  .agent-badges {
-    display: flex;
-    align-items: center;
-    gap: var(--space-md);
-  }
-
-  .status-badge {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-family: var(--font-body);
-    font-size: 13px;
-  }
-
-  .status-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    flex-shrink: 0;
-  }
-
-  .tier-badge {
-    font-family: var(--font-label);
-    font-size: 6px;
-    letter-spacing: 0.1em;
-  }
-
-  .tab-nav {
-    display: flex;
-    align-items: center;
-    gap: 0;
-    border-bottom: 1px solid var(--fo-border);
-    margin-bottom: var(--space-lg);
-  }
-
-  .tab-btn {
-    font-family: var(--font-label);
-    font-size: 7px;
-    letter-spacing: 0.1em;
-    color: var(--text-muted);
-    background: none;
-    border: none;
-    border-bottom: 2px solid transparent;
-    padding: var(--space-sm) var(--space-lg);
-    cursor: pointer;
-    margin-bottom: -1px;
-    transition:
-      color 0.15s ease,
-      border-color 0.15s ease;
-  }
-
-  .tab-btn:hover {
-    color: var(--fo-plum);
-  }
-
-  .tab-btn.active {
-    color: var(--fo-plum);
-    border-bottom-color: var(--fo-plum);
-  }
-
-  .tab-content {
-    min-height: 200px;
-  }
-
-  .edit-form {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-lg);
-    max-width: 560px;
-  }
-
-  .field {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-sm);
-  }
-
-  .field-label {
-    font-family: var(--font-body);
-    font-size: 13px;
-    color: var(--text-muted);
-  }
-
-  .field-input {
-    font-family: var(--font-body);
-    font-size: 16px;
-    padding: 10px 14px;
-    background: var(--fo-card);
-    border: 1px solid var(--fo-border);
-    border-radius: var(--radius-md);
-    color: inherit;
-    outline: none;
-    transition: border-color 0.15s;
-    width: 100%;
-    box-sizing: border-box;
-  }
-
-  .field-input:focus {
-    border-color: var(--fo-plum-m);
-    outline: 2px solid var(--fo-plum-p);
-    outline-offset: 1px;
-  }
-
-  .field-textarea {
-    resize: vertical;
-    line-height: 1.65;
-  }
-
-  .field-select {
-    cursor: pointer;
-  }
-
-  .field-error {
-    font-family: var(--font-body);
-    font-size: 13px;
-    color: var(--error);
-    margin: 0;
-  }
-
-  .field-success {
-    font-family: var(--font-body);
-    font-size: 13px;
-    color: var(--accent-teal);
-    margin: 0;
-  }
-
-  .form-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--space-md);
-    margin-top: var(--space-sm);
-  }
-
-  .btn-primary {
-    display: inline-flex;
-    align-items: center;
-    padding: 10px 18px;
-    background: var(--fo-plum);
-    color: white;
-    font-family: var(--font-body);
-    font-size: 13px;
-    font-weight: 600;
-    border: none;
-    border-radius: var(--radius-md);
-    cursor: pointer;
-    transition: background 0.15s;
-    text-decoration: none;
-  }
-
-  .btn-primary:hover:not(:disabled) {
-    background: var(--fo-plum-m);
-  }
-
-  .btn-primary:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-
-  .btn-secondary {
-    display: inline-flex;
-    align-items: center;
-    padding: 10px 18px;
-    background: transparent;
-    color: var(--text-muted);
-    font-family: var(--font-body);
-    font-size: 13px;
-    font-weight: 600;
-    border: 1px solid var(--fo-border);
-    border-radius: var(--radius-md);
-    cursor: pointer;
-    transition: background 0.15s;
-    text-decoration: none;
-  }
-
-  .btn-secondary:hover {
-    background: var(--fo-bg2);
-  }
-
-  .agent-meta {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-sm);
-    border-top: 1px solid var(--fo-border);
-    padding-top: var(--space-xl);
-    margin-top: var(--space-xl);
-  }
-
-  .meta-row {
-    display: flex;
-    gap: var(--space-xl);
-  }
-
-  .meta-label {
-    font-family: var(--font-body);
-    font-size: 13px;
-    color: var(--text-muted);
-    width: 120px;
-    flex-shrink: 0;
-  }
-
-  .meta-value {
-    font-family: var(--font-body);
-    font-size: 13px;
-  }
-
-  .empty-state {
-    font-family: var(--font-body);
-    font-size: 13px;
-    color: var(--text-muted);
-    padding: var(--space-xl);
-    text-align: center;
-  }
-
-  .skill-loadout {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-md);
-  }
-
-  .loadout-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--space-md);
-  }
-
-  .loadout-title {
-    font-family: var(--font-display);
-    font-size: 16px;
-    font-weight: 600;
-    color: var(--fo-plum);
-    margin: 0;
-  }
-
-  .slot-meter {
-    display: flex;
-    align-items: center;
-    gap: var(--space-sm);
-  }
-
-  .slot-label {
-    font-family: var(--font-label);
-    font-size: 6px;
-    letter-spacing: 0.1em;
-    color: var(--text-muted);
-  }
-
-  .slot-bar {
-    display: flex;
-    gap: 3px;
-  }
-
-  .slot-pip {
-    width: 8px;
-    height: 8px;
-    border-radius: 2px;
-    border: 1px solid var(--fo-border);
-    background: transparent;
-    transition: background 0.2s ease;
-  }
-
-  .slot-pip.filled {
-    background: var(--fo-plum);
-    border-color: var(--fo-plum);
-  }
-
-  .slot-count {
-    font-family: var(--font-mono);
-    font-size: 11px;
-    color: var(--text-muted);
-  }
-
-  .loading-state {
-    display: flex;
-    align-items: center;
-    gap: var(--space-sm);
-    padding: var(--space-xl);
-    justify-content: center;
-  }
-
-  .loading-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: var(--fo-plum);
-    animation: pulse 1s ease infinite;
-  }
-
-  @keyframes pulse {
-    0%,
-    100% {
-      opacity: 0.3;
-    }
-    50% {
-      opacity: 1;
-    }
-  }
-
-  .loading-text {
-    font-size: 12px;
-    color: var(--text-muted);
-  }
-
-  .error-state {
-    text-align: center;
-    padding: var(--space-lg);
-  }
-
-  .error-text {
-    font-size: 12px;
-    color: var(--error);
-    margin: 0 0 var(--space-sm);
-  }
-
-  .retry-btn {
-    font-family: var(--font-label);
-    font-size: 7px;
-    letter-spacing: 0.1em;
-    color: var(--fo-plum);
-    background: none;
-    border: 1px solid var(--fo-plum);
-    padding: 4px 12px;
-    border-radius: 3px;
-    cursor: pointer;
-  }
-
-  .retry-btn:hover {
-    background: rgba(124, 58, 237, 0.1);
-  }
-
-  .equipped-section {
-    min-height: 40px;
-  }
-
-  .equipped-list,
-  .available-list {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-sm);
-  }
-
-  .equipped-card,
-  .available-card {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--space-md);
-    padding: var(--space-sm) var(--space-md);
-    background: var(--fo-card);
-    border: 1px solid var(--fo-border);
-    border-radius: var(--radius-md);
-    transition: border-color 0.15s ease;
-  }
-
-  .equipped-card:hover,
-  .available-card:hover {
-    border-color: var(--fo-plum);
-  }
-
-  .skill-info {
-    display: flex;
-    align-items: center;
-    gap: var(--space-sm);
-    flex: 1;
-    min-width: 0;
-  }
-
-  .skill-cat-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    flex-shrink: 0;
-  }
-
-  .skill-meta {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    flex: 1;
-    min-width: 0;
-  }
-
-  .skill-name {
-    font-family: var(--font-body);
-    font-size: 13px;
-    font-weight: 500;
-    color: var(--text);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .skill-desc {
-    font-size: 11px;
-    color: var(--text-muted);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .skill-version {
-    font-family: var(--font-mono);
-    font-size: 10px;
-    color: var(--text-muted);
-    flex-shrink: 0;
-  }
-
-  .skill-class-badge {
-    font-family: var(--font-label);
-    font-size: 6px;
-    letter-spacing: 0.1em;
-    color: var(--text-muted);
-    border: 1px solid var(--fo-border);
-    padding: 1px 4px;
-    border-radius: 2px;
-    flex-shrink: 0;
-  }
-
-  .unequip-btn,
-  .equip-btn {
-    font-family: var(--font-label);
-    font-size: 7px;
-    letter-spacing: 0.1em;
-    padding: 4px 10px;
-    border-radius: 3px;
-    cursor: pointer;
-    flex-shrink: 0;
-    border: 1px solid;
-    transition: all 0.15s ease;
-  }
-
-  .unequip-btn {
-    color: var(--error);
-    background: transparent;
-    border-color: rgba(239, 68, 68, 0.25);
-  }
-
-  .unequip-btn:hover:not(:disabled) {
-    background: rgba(239, 68, 68, 0.1);
-    border-color: var(--error);
-  }
-
-  .equip-btn {
-    color: var(--accent-teal);
-    background: transparent;
-    border-color: rgba(45, 212, 191, 0.25);
-  }
-
-  .equip-btn:hover:not(:disabled) {
-    background: rgba(45, 212, 191, 0.1);
-    border-color: var(--accent-teal);
-  }
-
-  .equip-btn:disabled,
-  .unequip-btn:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-
-  .library-toggle {
-    font-family: var(--font-label);
-    font-size: 7px;
-    letter-spacing: 0.1em;
-    color: var(--fo-plum);
-    background: none;
-    border: 1px solid var(--fo-border);
-    padding: 6px 14px;
-    border-radius: 4px;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    gap: var(--space-sm);
-    align-self: flex-start;
-    transition: all 0.15s ease;
-  }
-
-  .library-toggle:hover {
-    border-color: var(--fo-plum);
-    background: rgba(124, 58, 237, 0.06);
-  }
-
-  .toggle-arrow {
-    display: inline-block;
-    width: 0;
-    height: 0;
-    border-left: 3px solid transparent;
-    border-right: 3px solid transparent;
-    border-top: 4px solid currentColor;
-    transition: transform 0.2s ease;
-  }
-
-  .toggle-arrow.open {
-    transform: rotate(180deg);
-  }
-
-  .library-section {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-md);
-    padding: var(--space-md);
-    background: rgba(124, 58, 237, 0.03);
-    border: 1px solid var(--fo-border);
-    border-radius: var(--radius-md);
-  }
-
-  .filter-bar {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-  }
-
-  .filter-chip {
-    font-family: var(--font-label);
-    font-size: 6px;
-    letter-spacing: 0.1em;
-    color: var(--text-muted);
-    background: transparent;
-    border: 1px solid var(--fo-border);
-    padding: 3px 8px;
-    border-radius: 3px;
-    cursor: pointer;
-    transition: all 0.15s ease;
-  }
-
-  .filter-chip:hover {
-    color: var(--text);
-    border-color: var(--fo-plum);
-  }
-
-  .filter-chip.active {
-    color: var(--text);
-    background: rgba(124, 58, 237, 0.15);
-    border-color: var(--fo-plum);
-  }
-
-  .empty-msg {
-    font-size: 12px;
-    color: var(--text-muted);
-    text-align: center;
-    padding: var(--space-lg);
-    margin: 0;
-  }
-
-  .activity-list {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-sm);
-  }
-
-  .activity-row {
-    display: flex;
-    align-items: center;
-    gap: var(--space-md);
-    padding: var(--space-sm) var(--space-md);
-    background: var(--fo-card);
-    border: 1px solid var(--fo-border);
-    border-radius: var(--radius-md);
-  }
-
-  .activity-icon {
-    width: 28px;
-    height: 28px;
-    border-radius: var(--radius-sm);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    font-size: 12px;
-  }
-
-  .activity-icon.execution {
-    background: rgba(45, 212, 191, 0.1);
-    color: var(--accent-teal);
-  }
-
-  .activity-icon.skill {
-    background: rgba(124, 58, 237, 0.1);
-    color: var(--accent);
-  }
-
-  .activity-icon.karma {
-    background: rgba(251, 191, 36, 0.1);
-    color: var(--karma);
-  }
-
-  .activity-info {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    flex: 1;
-    min-width: 0;
-  }
-
-  .activity-desc {
-    font-family: var(--font-body);
-    font-size: 13px;
-    color: var(--text);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .activity-time {
-    font-family: var(--font-body);
-    font-size: 11px;
-    color: var(--text-muted);
-  }
-
-  .perf-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    gap: var(--space-md);
-    margin-bottom: var(--space-xl);
-  }
-
-  .perf-card {
-    padding: var(--space-md);
-    background: var(--fo-card);
-    border: 1px solid var(--fo-border);
-    border-radius: var(--radius-md);
-  }
-
-  .perf-card-title {
-    font-family: var(--font-label);
-    font-size: 6px;
-    letter-spacing: 0.1em;
-    color: var(--text-muted);
-    margin: 0 0 var(--space-sm);
-  }
-
-  .perf-card-value {
-    font-family: var(--font-display);
-    font-size: 24px;
-    font-weight: 600;
-    color: var(--fo-plum);
-    margin: 0;
-  }
-
-  .cost-history {
-    margin-top: var(--space-lg);
-  }
-
-  .perf-section-title {
-    font-family: var(--font-label);
-    font-size: 7px;
-    letter-spacing: 0.1em;
-    color: var(--text-muted);
-    margin: 0 0 var(--space-md);
-  }
-
-  .cost-table {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-  }
-
-  .cost-header {
-    display: flex;
-    justify-content: space-between;
-    padding: var(--space-sm) var(--space-md);
-    background: var(--fo-bg2);
-    border-radius: var(--radius-sm);
-    font-family: var(--font-label);
-    font-size: 6px;
-    letter-spacing: 0.1em;
-    color: var(--text-muted);
-  }
-
-  .cost-row {
-    display: flex;
-    justify-content: space-between;
-    padding: var(--space-sm) var(--space-md);
-    border-bottom: 1px solid var(--fo-border);
-  }
-
-  .cost-date {
-    font-family: var(--font-body);
-    font-size: 13px;
-    color: var(--text);
-  }
-
-  .cost-amount {
-    font-family: var(--font-mono);
-    font-size: 13px;
-    color: var(--text);
-  }
-
-  .danger-section {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-lg);
-    max-width: 560px;
-  }
-
-  .danger-title {
-    font-family: var(--font-display);
-    font-size: 18px;
-    font-weight: 600;
-    color: var(--error);
-    margin: 0;
-  }
-
-  .danger-desc {
-    font-family: var(--font-body);
-    font-size: 14px;
-    line-height: 1.6;
-    color: var(--text);
-    margin: 0;
-  }
-
-  .danger-confirm {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-sm);
-  }
-
-  .btn-danger {
-    display: inline-flex;
-    align-items: center;
-    padding: 10px 18px;
-    background: var(--error);
-    color: white;
-    font-family: var(--font-body);
-    font-size: 13px;
-    font-weight: 600;
-    border: none;
-    border-radius: var(--radius-md);
-    cursor: pointer;
-    transition: opacity 0.15s;
-    align-self: flex-start;
-  }
-
-  .btn-danger:hover:not(:disabled) {
-    opacity: 0.85;
-  }
-
-  .btn-danger:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
+  .agent-detail { max-width: 800px; }
+  .back-row { margin-bottom: var(--space-xl); }
+  .back-link { font-family: var(--font-body); font-size: 13px; color: var(--text-muted); text-decoration: none; transition: color 0.15s; }
+  .back-link:hover { color: var(--accent, var(--fo-plum)); }
+
+  .agent-header { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-lg); margin-bottom: var(--space-xl); flex-wrap: wrap; }
+  .header-identity { display: flex; align-items: center; gap: var(--space-md); }
+  .avatar { width: 48px; height: 48px; border-radius: var(--radius-xl); border: 1.5px solid; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .avatar-letter { font-family: var(--font-display); font-size: 22px; font-weight: 600; line-height: 1; }
+  .header-text { display: flex; flex-direction: column; gap: 2px; }
+  .agent-name { font-family: var(--font-display); font-size: clamp(20px, 3vw, 28px); font-weight: 600; color: var(--text); line-height: 1.2; margin: 0; }
+  .agent-desc { font-family: var(--font-body); font-size: 13px; color: var(--text-muted); margin: 0; }
+  .agent-badges { display: flex; align-items: center; gap: var(--space-sm); flex-wrap: wrap; }
+  .status-badge { display: flex; align-items: center; gap: 5px; font-family: var(--font-body); font-size: 12px; color: var(--text-muted); }
+  .status-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+  .class-badge { font-family: var(--font-label); font-size: 6px; letter-spacing: 0.1em; padding: 2px 8px; border: 1px solid; border-radius: 3px; }
+  .score-badge { font-family: var(--font-mono); font-size: 12px; color: var(--text-muted); }
+
+  .tab-nav { display: flex; align-items: center; gap: 0; border-bottom: 1px solid var(--border, var(--fo-border)); margin-bottom: var(--space-lg); overflow-x: auto; }
+  .tab-btn { font-family: var(--font-label); font-size: 7px; letter-spacing: 0.1em; color: var(--text-muted); background: none; border: none; border-bottom: 2px solid transparent; padding: var(--space-sm) var(--space-lg); cursor: pointer; margin-bottom: -1px; white-space: nowrap; transition: color 0.15s ease, border-color 0.15s ease; }
+  .tab-btn:hover { color: var(--accent, var(--fo-plum)); }
+  .tab-btn.active { color: var(--accent, var(--fo-plum)); border-bottom-color: var(--accent, var(--fo-plum)); }
+  .tab-content { min-height: 200px; }
+
+  .edit-form { display: flex; flex-direction: column; gap: var(--space-lg); max-width: 560px; }
+  .field { display: flex; flex-direction: column; gap: var(--space-sm); }
+  .field-label { font-family: var(--font-body); font-size: 13px; color: var(--text-muted); }
+  .field-input { font-family: var(--font-body); font-size: 16px; padding: 10px 14px; background: var(--card, var(--fo-card)); border: 1px solid var(--border, var(--fo-border)); border-radius: var(--radius-md); color: inherit; outline: none; transition: border-color 0.15s; width: 100%; box-sizing: border-box; }
+  .field-input:focus { border-color: var(--accent, var(--fo-plum-m)); outline: 2px solid var(--accent-dim, var(--fo-plum-p)); outline-offset: 1px; }
+  .field-textarea { resize: vertical; line-height: 1.65; }
+  .field-select { cursor: pointer; }
+  .field-error { font-family: var(--font-body); font-size: 13px; color: var(--error); margin: 0; }
+  .field-success { font-family: var(--font-body); font-size: 13px; color: var(--accent-teal); margin: 0; }
+  .form-actions { display: flex; align-items: center; gap: var(--space-md); margin-top: var(--space-sm); }
+
+  .btn-primary { display: inline-flex; align-items: center; padding: 10px 18px; background: var(--accent, var(--fo-plum)); color: white; font-family: var(--font-body); font-size: 13px; font-weight: 600; border: none; border-radius: var(--radius-md); cursor: pointer; transition: background 0.15s; text-decoration: none; }
+  .btn-primary:hover:not(:disabled) { background: var(--accent-m, var(--fo-plum-m)); }
+  .btn-primary:disabled { opacity: 0.6; cursor: not-allowed; }
+  .btn-secondary { display: inline-flex; align-items: center; padding: 10px 18px; background: transparent; color: var(--text-muted); font-family: var(--font-body); font-size: 13px; font-weight: 600; border: 1px solid var(--border, var(--fo-border)); border-radius: var(--radius-md); cursor: pointer; transition: background 0.15s; text-decoration: none; }
+  .btn-secondary:hover { background: var(--bg2, var(--fo-bg2)); }
+
+  .agent-meta { display: flex; flex-direction: column; gap: var(--space-sm); border-top: 1px solid var(--border, var(--fo-border)); padding-top: var(--space-xl); margin-top: var(--space-xl); }
+  .meta-row { display: flex; gap: var(--space-xl); }
+  .meta-label { font-family: var(--font-body); font-size: 13px; color: var(--text-muted); width: 120px; flex-shrink: 0; }
+  .meta-value { font-family: var(--font-body); font-size: 13px; }
+
+  .delete-section { margin-top: var(--space-2xl); padding-top: var(--space-xl); border-top: 1px solid var(--border, var(--fo-border)); }
+  .btn-danger-outline { display: inline-flex; align-items: center; padding: 8px 16px; background: transparent; color: var(--error); font-family: var(--font-body); font-size: 13px; font-weight: 500; border: 1px solid rgba(248, 113, 113, 0.3); border-radius: var(--radius-md); cursor: pointer; transition: all 0.15s; }
+  .btn-danger-outline:hover { background: var(--error-dim); border-color: var(--error); }
+  .danger-box { display: flex; flex-direction: column; gap: var(--space-lg); max-width: 560px; padding: var(--space-lg); border: 1px solid rgba(248, 113, 113, 0.2); border-radius: var(--radius-md); background: var(--error-dim); }
+  .danger-title { font-family: var(--font-display); font-size: 18px; font-weight: 600; color: var(--error); margin: 0; }
+  .danger-desc { font-family: var(--font-body); font-size: 14px; line-height: 1.6; color: var(--text); margin: 0; }
+  .danger-confirm { display: flex; flex-direction: column; gap: var(--space-sm); }
+  .btn-danger { display: inline-flex; align-items: center; padding: 10px 18px; background: var(--error); color: white; font-family: var(--font-body); font-size: 13px; font-weight: 600; border: none; border-radius: var(--radius-md); cursor: pointer; transition: opacity 0.15s; }
+  .btn-danger:hover:not(:disabled) { opacity: 0.85; }
+  .btn-danger:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .skill-loadout { display: flex; flex-direction: column; gap: var(--space-md); }
+  .loadout-header { display: flex; align-items: center; justify-content: space-between; gap: var(--space-md); }
+  .loadout-title { font-family: var(--font-display); font-size: 16px; font-weight: 600; color: var(--text); margin: 0; }
+  .slot-meter { display: flex; align-items: center; gap: var(--space-sm); }
+  .slot-label { font-family: var(--font-label); font-size: 6px; letter-spacing: 0.1em; color: var(--text-muted); }
+  .slot-bar { display: flex; gap: 3px; }
+  .slot-pip { width: 8px; height: 8px; border-radius: 2px; border: 1px solid var(--border, var(--fo-border)); background: transparent; transition: background 0.2s ease; }
+  .slot-pip.filled { background: var(--accent, var(--fo-plum)); border-color: var(--accent, var(--fo-plum)); }
+  .slot-count { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); }
+  .capacity-note { font-family: var(--font-body); font-size: 12px; color: var(--text-muted); margin: 0; }
+
+  .loading-state { display: flex; align-items: center; gap: var(--space-sm); padding: var(--space-xl); justify-content: center; }
+  .loading-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--accent, var(--fo-plum)); animation: pulse 1s ease infinite; }
+  @keyframes pulse { 0%, 100% { opacity: 0.3; } 50% { opacity: 1; } }
+  .loading-text { font-size: 12px; color: var(--text-muted); }
+  .error-state { text-align: center; padding: var(--space-lg); }
+  .error-text { font-size: 12px; color: var(--error); margin: 0 0 var(--space-sm); }
+  .retry-btn { font-family: var(--font-label); font-size: 7px; letter-spacing: 0.1em; color: var(--accent, var(--fo-plum)); background: none; border: 1px solid var(--accent, var(--fo-plum)); padding: 4px 12px; border-radius: 3px; cursor: pointer; }
+  .retry-btn:hover { background: rgba(124, 58, 237, 0.1); }
+
+  .equipped-section { min-height: 40px; }
+  .equipped-list, .available-list { display: flex; flex-direction: column; gap: var(--space-sm); }
+  .equipped-card, .available-card { display: flex; align-items: center; justify-content: space-between; gap: var(--space-md); padding: var(--space-sm) var(--space-md); background: var(--card, var(--fo-card)); border: 1px solid var(--border, var(--fo-border)); border-radius: var(--radius-md); transition: border-color 0.15s ease; }
+  .equipped-card:hover, .available-card:hover { border-color: var(--accent, var(--fo-plum)); }
+  .skill-info { display: flex; align-items: center; gap: var(--space-sm); flex: 1; min-width: 0; }
+  .skill-cat-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+  .skill-meta { display: flex; flex-direction: column; gap: 2px; flex: 1; min-width: 0; }
+  .skill-name { font-family: var(--font-body); font-size: 13px; font-weight: 500; color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .skill-desc { font-size: 11px; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .skill-version { font-family: var(--font-mono); font-size: 10px; color: var(--text-muted); flex-shrink: 0; }
+  .skill-class-badge { font-family: var(--font-label); font-size: 6px; letter-spacing: 0.1em; color: var(--text-muted); border: 1px solid var(--border, var(--fo-border)); padding: 1px 4px; border-radius: 2px; flex-shrink: 0; }
+
+  .unequip-btn, .equip-btn { font-family: var(--font-label); font-size: 7px; letter-spacing: 0.1em; padding: 4px 10px; border-radius: 3px; cursor: pointer; flex-shrink: 0; border: 1px solid; transition: all 0.15s ease; }
+  .unequip-btn { color: var(--error); background: transparent; border-color: rgba(239, 68, 68, 0.25); }
+  .unequip-btn:hover:not(:disabled) { background: rgba(239, 68, 68, 0.1); border-color: var(--error); }
+  .equip-btn { color: var(--accent-teal); background: transparent; border-color: rgba(45, 212, 191, 0.25); }
+  .equip-btn:hover:not(:disabled) { background: rgba(45, 212, 191, 0.1); border-color: var(--accent-teal); }
+  .equip-btn:disabled, .unequip-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+  .library-toggle { font-family: var(--font-label); font-size: 7px; letter-spacing: 0.1em; color: var(--accent, var(--fo-plum)); background: none; border: 1px solid var(--border, var(--fo-border)); padding: 6px 14px; border-radius: 4px; cursor: pointer; display: flex; align-items: center; gap: var(--space-sm); align-self: flex-start; transition: all 0.15s ease; }
+  .library-toggle:hover { border-color: var(--accent, var(--fo-plum)); background: rgba(124, 58, 237, 0.06); }
+  .toggle-arrow { display: inline-block; width: 0; height: 0; border-left: 3px solid transparent; border-right: 3px solid transparent; border-top: 4px solid currentColor; transition: transform 0.2s ease; }
+  .toggle-arrow.open { transform: rotate(180deg); }
+  .library-section { display: flex; flex-direction: column; gap: var(--space-md); padding: var(--space-md); background: rgba(124, 58, 237, 0.03); border: 1px solid var(--border, var(--fo-border)); border-radius: var(--radius-md); }
+  .filter-bar { display: flex; flex-wrap: wrap; gap: 4px; }
+  .filter-chip { font-family: var(--font-label); font-size: 6px; letter-spacing: 0.1em; color: var(--text-muted); background: transparent; border: 1px solid var(--border, var(--fo-border)); padding: 3px 8px; border-radius: 3px; cursor: pointer; transition: all 0.15s ease; }
+  .filter-chip:hover { color: var(--text); border-color: var(--accent, var(--fo-plum)); }
+  .filter-chip.active { color: var(--text); background: rgba(124, 58, 237, 0.15); border-color: var(--accent, var(--fo-plum)); }
+  .empty-msg { font-size: 12px; color: var(--text-muted); text-align: center; padding: var(--space-lg); margin: 0; }
+
+  .tools-section { display: flex; flex-direction: column; gap: var(--space-md); }
+  .section-title { font-family: var(--font-display); font-size: 16px; font-weight: 600; color: var(--text); margin: 0; }
+  .empty-tools { display: flex; flex-direction: column; align-items: center; gap: var(--space-md); padding: var(--space-2xl) 0; }
+  .tool-list { display: flex; flex-direction: column; gap: var(--space-sm); }
+  .tool-card { display: flex; align-items: center; justify-content: space-between; gap: var(--space-md); padding: var(--space-sm) var(--space-md); background: var(--card, var(--fo-card)); border: 1px solid var(--border, var(--fo-border)); border-radius: var(--radius-md); }
+  .tool-info { display: flex; align-items: center; gap: var(--space-sm); flex: 1; min-width: 0; }
+  .tool-icon { width: 28px; height: 28px; border-radius: var(--radius-sm); background: var(--bg2, var(--fo-bg2)); display: flex; align-items: center; justify-content: center; flex-shrink: 0; color: var(--text-muted); }
+  .tool-meta { display: flex; flex-direction: column; gap: 2px; flex: 1; min-width: 0; }
+  .tool-name { font-family: var(--font-body); font-size: 13px; font-weight: 500; color: var(--text); }
+  .tool-provider { font-family: var(--font-body); font-size: 11px; color: var(--text-muted); }
+  .tool-status { font-family: var(--font-label); font-size: 6px; letter-spacing: 0.1em; color: var(--text-muted); padding: 2px 6px; border: 1px solid var(--border, var(--fo-border)); border-radius: 3px; flex-shrink: 0; }
+  .tool-status.connected { color: var(--accent-teal); border-color: rgba(45, 212, 191, 0.3); background: rgba(45, 212, 191, 0.08); }
+
+  .history-section { display: flex; flex-direction: column; gap: var(--space-lg); }
+  .empty-state-text { font-family: var(--font-body); font-size: 13px; color: var(--text-muted); text-align: center; padding: var(--space-xl); }
+  .perf-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: var(--space-md); }
+  .perf-card { padding: var(--space-md); background: var(--card, var(--fo-card)); border: 1px solid var(--border, var(--fo-border)); border-radius: var(--radius-md); }
+  .perf-card-title { font-family: var(--font-label); font-size: 6px; letter-spacing: 0.1em; color: var(--text-muted); margin: 0 0 var(--space-sm); }
+  .perf-card-value { font-family: var(--font-display); font-size: 24px; font-weight: 600; color: var(--accent, var(--fo-plum)); margin: 0; }
+  .activity-list { display: flex; flex-direction: column; gap: var(--space-sm); }
+  .activity-row { display: flex; align-items: center; gap: var(--space-md); padding: var(--space-sm) var(--space-md); background: var(--card, var(--fo-card)); border: 1px solid var(--border, var(--fo-border)); border-radius: var(--radius-md); }
+  .activity-icon { width: 28px; height: 28px; border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; flex-shrink: 0; font-size: 12px; }
+  .activity-icon.execution { background: rgba(45, 212, 191, 0.1); color: var(--accent-teal); }
+  .activity-icon.skill { background: rgba(124, 58, 237, 0.1); color: var(--accent); }
+  .activity-icon.karma { background: rgba(251, 191, 36, 0.1); color: var(--karma); }
+  .activity-info { display: flex; flex-direction: column; gap: 2px; flex: 1; min-width: 0; }
+  .activity-desc { font-family: var(--font-body); font-size: 13px; color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .activity-time { font-family: var(--font-body); font-size: 11px; color: var(--text-muted); }
+  .cost-history { margin-top: var(--space-lg); }
+  .perf-section-title { font-family: var(--font-label); font-size: 7px; letter-spacing: 0.1em; color: var(--text-muted); margin: 0 0 var(--space-md); }
+  .cost-table { display: flex; flex-direction: column; gap: 2px; }
+  .cost-header { display: flex; justify-content: space-between; padding: var(--space-sm) var(--space-md); background: var(--bg2, var(--fo-bg2)); border-radius: var(--radius-sm); font-family: var(--font-label); font-size: 6px; letter-spacing: 0.1em; color: var(--text-muted); }
+  .cost-row { display: flex; justify-content: space-between; padding: var(--space-sm) var(--space-md); border-bottom: 1px solid var(--border, var(--fo-border)); }
+  .cost-date { font-family: var(--font-body); font-size: 13px; color: var(--text); }
+  .cost-amount { font-family: var(--font-mono); font-size: 13px; color: var(--text); }
+
+  .evolution-section { display: flex; flex-direction: column; gap: var(--space-2xl); }
+  .class-progression { display: flex; flex-direction: column; gap: var(--space-md); }
+  .progression-track { display: flex; align-items: flex-start; gap: 0; }
+  .progression-step { display: flex; flex-direction: column; align-items: center; gap: var(--space-xs); min-width: 80px; }
+  .step-dot { width: 16px; height: 16px; border-radius: 50%; border: 2px solid; transition: all 0.2s; }
+  .progression-step.current .step-dot { box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.2); }
+  .step-label { font-family: var(--font-label); font-size: 6px; letter-spacing: 0.1em; text-align: center; }
+  .step-capacity { font-family: var(--font-body); font-size: 10px; color: var(--text-muted); text-align: center; }
+  .step-connector { flex: 1; height: 2px; background: var(--border, var(--fo-border)); margin-top: 7px; min-width: 24px; }
+  .step-connector.filled { background: var(--accent, var(--fo-plum)); }
+  .score-section { display: flex; flex-direction: column; gap: var(--space-sm); }
+  .score-display { display: flex; align-items: baseline; gap: var(--space-xs); }
+  .score-value { font-family: var(--font-display); font-size: 36px; font-weight: 600; color: var(--karma, var(--fo-gold)); }
+  .score-max { font-family: var(--font-body); font-size: 14px; color: var(--text-muted); }
+  .lineage-section { display: flex; flex-direction: column; gap: var(--space-md); }
 </style>


### PR DESCRIPTION
## Summary
- Rebuild the Team detail page with 5 tabs: **Profile**, **Skills**, **Tools**, **History**, **Evolution** (was edit/skills/activity/performance/danger)
- Add avatar header with class-colored initial (Novice=#3B82F6, Understudy=#8B5CF6, Artisan=#F59E0B), status dot, class badge, and composite score
- **Profile tab**: editable name/description/adapter, class tier display, metadata, inline delete with expandable confirmation
- **Skills tab**: equipped skills with unequip, available library with equip, slot meter showing capacity (Novice=3, Understudy=5, Artisan=8)
- **Tools tab**: renders tool connections list from server data with connection status badges
- **History tab**: execution activity list with spend summary and cost history table
- **Evolution tab**: class progression track visualization, composite fitness score display, soul lineage placeholder

## Test plan
- [ ] Navigate to /team and verify agent list renders with filter chips
- [ ] Click an agent card to navigate to /team/[id]
- [ ] Verify all 5 tabs switch correctly
- [ ] Profile tab: edit name/description/adapter and save
- [ ] Skills tab: equip/unequip skills, verify slot capacity display
- [ ] Tools tab: verify tool connections display (or empty state with import link)
- [ ] History tab: verify activity list and cost data
- [ ] Evolution tab: verify class progression track highlights current class
- [ ] Delete agent via Profile tab confirmation flow
- [ ] Navigate to /team/new and create a new agent

Generated with Claude Code