### PR TITLE
fix: onboarding 500 — register missing DB migrations in journal

### DIFF
--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -141,6 +141,20 @@
       "when": 1773400000000,
       "tag": "0020_tool_registry",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1773500000000,
+      "tag": "0021_marketplace_reviews",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1773600000000,
+      "tag": "0022_paperclip_tables_inline",
+      "breakpoints": true
     }
   ]
 }

--- a/services/execution-service/src/routes/onboarding.ts
+++ b/services/execution-service/src/routes/onboarding.ts
@@ -127,7 +127,12 @@ export const onboardingRoutes: FastifyPluginAsync = async (app) => {
         budgetMonthlyCents: budgetCents,
       });
     } catch (err) {
-      console.error('[onboarding] Failed to create company:', (err as Error).message);
+      const message = (err as Error).message;
+      console.error('[onboarding] Failed to create company:', message);
+      // If the error is a missing table, give a helpful message
+      if (message.includes('relation') && message.includes('does not exist')) {
+        return reply.code(500).send({ error: 'Database tables not initialized. Run: pnpm db:migrate' });
+      }
       return reply.code(500).send({ error: 'Failed to create company' });
     }
 


### PR DESCRIPTION
## Summary
- Registered migrations 0021 (marketplace_reviews) and 0022 (paperclip_tables_inline) in the Drizzle migration journal
- These SQL files existed but were never added to `_journal.json`, so `pnpm db:migrate` would never apply them
- The `companies` and related tables from migration 0022 are required for the onboarding flow to work
- Added helpful error message when tables don't exist

Closes #188

## After merging
Run `pnpm db:migrate` on the database to apply the missing migrations.

## Test plan
- [ ] Run `pnpm db:migrate` 
- [ ] Sign in with Google
- [ ] Verify onboarding flow loads without 500
- [ ] Complete onboarding and verify company/agents are created